### PR TITLE
#15 Specified base path for Github pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [svelte()],
+  base: '/music/'
 })


### PR DESCRIPTION
# #15 Specified base path for Github pages

Specifies `"/music/"` as the base path to Vite on CD build script to fix missing assets folder issues on Github pages