### PR TITLE
#15 Specified base path for Github pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install App
       uses: ./.github/workflows/scripts/install
     - name: Build App
-      run: pnpm run build
+      run: pnpm run build --base "/music/"
     - name: Upload App
       uses: actions/upload-pages-artifact@v3
       with:


### PR DESCRIPTION
# #15 Specified base path for Github pages

Specifies `"/music/"` as the base path to Vite on CD build script to fix missing assets folder issues on Github pages