### PR TITLE
#30 Fixed CI Deprecated Node Version Warning

### DIFF
--- a/.github/workflows/scripts/install/action.yml
+++ b/.github/workflows/scripts/install/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v3
       with:
         version: 8
     - name: Install Node


### PR DESCRIPTION
# #30 Fixed CI Deprecated Node Version Warning

Fixes issue with pnpm action-setup deprecated Node version

## Changes

- Bumped `pnpm/action-setup` to `v3`