### PR TITLE
#51 Added linting error for console logs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -22,6 +22,8 @@ ignorePatterns:
   - /*
   - '!/src'
 rules:
+  'no-console':
+    - error
   '@typescript-eslint/no-unused-vars':
     - error
     - argsIgnorePattern: '^_'


### PR DESCRIPTION
# #51 Added linting error for console logs

Added an error rule for console logs in eslint

## Changes

- Added error on `no-console` to eslint