### PR TITLE
#45 Add note tooltip

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,1 @@
+export { default as tooltip } from './tooltip';

--- a/src/actions/tooltip.ts
+++ b/src/actions/tooltip.ts
@@ -7,7 +7,8 @@ const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
 
   node.addEventListener('mouseenter', handleMouseEnter);
   node.addEventListener('mouseleave', handleMouseLeave);
-  window.addEventListener('resize', handleResize);
+  window.addEventListener('resize', updateTooltipPosition);
+  window.addEventListener('scroll', updateTooltipPosition);
 
   function createTooltipElement() {
     const { x, y } = getTooltipPosition();
@@ -23,18 +24,18 @@ const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
     tooltipElement = null;
   }
 
-  function getTooltipPosition() {
-    const nodeBounds = node.getBoundingClientRect();
-    return {
-      x: nodeBounds.x + (nodeBounds.width / 2),
-      y: nodeBounds.y
-    };
-  }
-
-  function handleResize() {
+  function updateTooltipPosition() {
     if (!tooltipElement) return;
     const { x, y } = getTooltipPosition();
     tooltipElement.$set({ x, y });
+  }
+
+  function getTooltipPosition() {
+    const nodeBounds = node.getBoundingClientRect();
+    return {
+      x: nodeBounds.x + (nodeBounds.width / 2) + window.scrollX,
+      y: nodeBounds.y + window.scrollY
+    };
   }
 
   function handleMouseEnter() {
@@ -53,7 +54,8 @@ const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
     destroy() {
       node.removeEventListener('mouseenter', handleMouseEnter);
       node.removeEventListener('mouseleave', handleMouseLeave);
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', updateTooltipPosition);
+      window.removeEventListener('scroll', updateTooltipPosition);
       destroyTooltipElement();
     }
   };

--- a/src/actions/tooltip.ts
+++ b/src/actions/tooltip.ts
@@ -1,0 +1,46 @@
+import type { Action } from 'svelte/action';
+import Tooltip from '@/components/Tooltip';
+
+const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
+  const tooltipElement = new Tooltip({
+    props: { details: text },
+    target: document.body
+  });
+
+  handleResize();
+
+  node.addEventListener('mouseover', handleMouseOver);
+  node.addEventListener('mouseleave', handleMouseLeave);
+  window.addEventListener('resize', handleResize);
+
+  function handleResize() {
+    const { x, y, width } = node.getBoundingClientRect();
+    tooltipElement.$set({
+      x: x + (width / 2),
+      y
+    });
+  }
+
+  function handleMouseOver() {
+    handleResize();
+    tooltipElement.$set({ isVisible: true });
+  }
+
+  function handleMouseLeave() {
+    tooltipElement.$set({ isVisible: false });
+  }
+
+  return {
+    update({ text }) {
+      tooltipElement.$set({ details: text });
+    },
+    destroy() {
+      node.removeEventListener('mouseover', handleMouseOver);
+      node.removeEventListener('mouseleave', handleMouseLeave);
+      window.removeEventListener('resize', handleResize);
+      tooltipElement.$destroy();
+    }
+  };
+};
+
+export default tooltip;

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import type { Action } from 'svelte/action';
   import type { SelectedNote } from '@/types/SelectedNote';
-  import Tooltip from '@/components/Tooltip';
+  import { tooltip } from '@/actions';
 
   export let note = 'E';
   export let selectedNote: SelectedNote | null = null;
@@ -34,48 +33,6 @@
   $: getIntervalName = (note:string) => (
     getHighlightedNote(note)?.name
   );
-
-  const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
-    const tooltipElement = new Tooltip({
-      props: { details: text },
-      target: document.body
-    });
-
-    handleResize();
-
-    node.addEventListener('mouseover', handleMouseOver);
-    node.addEventListener('mouseleave', handleMouseLeave);
-    window.addEventListener('resize', handleResize);
-
-    function handleResize() {
-      const { x, y, width } = node.getBoundingClientRect();
-      tooltipElement.$set({
-        x: x + (width / 2),
-        y
-      });
-    }
-
-    function handleMouseOver() {
-      handleResize();
-      tooltipElement.$set({ isVisible: true });
-    }
-
-    function handleMouseLeave() {
-      tooltipElement.$set({ isVisible: false });
-    }
-
-    return {
-      update({ text }) {
-        tooltipElement.$set({ details: text });
-      },
-      destroy() {
-        node.removeEventListener('mouseover', handleMouseOver);
-        node.removeEventListener('mouseleave', handleMouseLeave);
-        window.removeEventListener('resize', handleResize);
-        tooltipElement.$destroy();
-      }
-    };
-  };
 </script>
 
 <button

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import type { Action } from 'svelte/action';
   import type { SelectedNote } from '@/types/SelectedNote';
+  import Tooltip from '@/components/Tooltip';
 
   export let note = 'E';
   export let selectedNote: SelectedNote | null = null;
@@ -28,12 +30,59 @@
   $: getHighlightedNote = (note: string) => (
     highlightedNotes.find(({ value }) => value === note)
   );
+
+  $: getIntervalName = (note:string) => (
+    getHighlightedNote(note)?.name
+  );
+
+  const tooltip: Action<HTMLElement, { text?: string }> = (node, { text }) => {
+    const tooltipElement = new Tooltip({
+      props: { details: text },
+      target: document.body
+    });
+
+    handleResize();
+
+    node.addEventListener('mouseover', handleMouseOver);
+    node.addEventListener('mouseleave', handleMouseLeave);
+    window.addEventListener('resize', handleResize);
+
+    function handleResize() {
+      const { x, y, width } = node.getBoundingClientRect();
+      tooltipElement.$set({
+        x: x + (width / 2),
+        y
+      });
+    }
+
+    function handleMouseOver() {
+      handleResize();
+      tooltipElement.$set({ isVisible: true });
+    }
+
+    function handleMouseLeave() {
+      tooltipElement.$set({ isVisible: false });
+    }
+
+    return {
+      update({ text }) {
+        tooltipElement.$set({ details: text });
+      },
+      destroy() {
+        node.removeEventListener('mouseover', handleMouseOver);
+        node.removeEventListener('mouseleave', handleMouseLeave);
+        window.removeEventListener('resize', handleResize);
+        tooltipElement.$destroy();
+      }
+    };
+  };
 </script>
 
 <button
   class="fret"
   title={getHighlightedNote(note)?.name}
   on:click={() => selectNote(note)}
+  use:tooltip={{ text: getIntervalName(note) }}
 >
   <div
     class:fret__indicator={isHighlighted(note) || isSelected(note)}

--- a/src/components/Piano/Piano.svelte
+++ b/src/components/Piano/Piano.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SelectedNote } from '@/types';
+  import { tooltip } from '@/actions';
 
   export let highlightedNotes: SelectedNote[] = [];
 
@@ -28,13 +29,19 @@
   $: getHighlightedNote = (note: string) => (
     highlightedNotes.find(({ value }) => value === note)
   );
+
+  $: getIntervalName = (note:string) => (
+    getHighlightedNote(note)?.name
+  );
 </script>
 
 <div class="container">
   <div class="piano">
     <div class="white-keys">
       {#each whiteKeys as note}
-        <div class="white-keys__key">
+        <div class="white-keys__key"
+          use:tooltip={{ text: getIntervalName(note) }}
+        >
           <div
             class="white-keys__indicator"
             class:white-keys__indicator--highlighted={isHighlighted(note)}
@@ -47,7 +54,9 @@
     </div>
     <div class="black-keys">
       {#each blackKeys as note}
-        <div class="black-keys__key">
+        <div class="black-keys__key"
+          use:tooltip={{ text: getIntervalName(note) }}
+        >
           <div
             class="black-keys__indicator"
             class:black-keys__indicator--highlighted={isHighlighted(note)}

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,0 +1,9 @@
+.tooltip {
+  position: absolute;
+  padding: 1rem;
+  color: white;
+  background-color: black;
+  outline: 2px solid red;
+  pointer-events: none;
+  transform: translate(-50%, -100%);
+}

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,9 +1,21 @@
 .tooltip {
+  --background-colour: rgb(90, 90, 90);
+  --tail-height: 0.5rem;
+
   position: absolute;
   padding: 1rem;
+  background-color: var(--background-colour);
   color: white;
-  background-color: black;
-  outline: 2px solid red;
   pointer-events: none;
-  transform: translate(-50%, -100%);
+  transform: translate(-50%, calc(-100% - var(--tail-height)));
+
+  &__tail {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: calc(var(--tail-height) * -1);
+    border-width: var(--tail-height);
+    border-style: solid;
+    border-color: var(--background-colour) transparent transparent ;
+  }
 }

--- a/src/components/Tooltip/Tooltip.svelte
+++ b/src/components/Tooltip/Tooltip.svelte
@@ -10,6 +10,7 @@
     style="left: {x}px; top: {y}px;"
   >
     {details}
+    <div class="tooltip__tail" />
   </div>
 {/if}
 

--- a/src/components/Tooltip/Tooltip.svelte
+++ b/src/components/Tooltip/Tooltip.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   export let details: string | undefined;
-  export let isVisible = false;
   export let x = 0;
   export let y = 0;
 </script>
 
-{#if isVisible && details}
+{#if details}
   <div
     class="tooltip"
     style="left: {x}px; top: {y}px;"

--- a/src/components/Tooltip/Tooltip.svelte
+++ b/src/components/Tooltip/Tooltip.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let details: string | undefined;
+  export let isVisible = false;
+  export let x = 0;
+  export let y = 0;
+</script>
+
+{#if isVisible && details}
+  <div
+    class="tooltip"
+    style="left: {x}px; top: {y}px;"
+  >
+    {details}
+  </div>
+{/if}
+
+<style lang="scss">
+  @import './Tooltip.scss';
+</style>

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Tooltip.svelte';


### PR DESCRIPTION
# #45 Add note tooltip

Adds a tooltip component and action, and implements in on frets and keys for interval names

## Changes

- Added Tooltip component
- Added tooltip action
- Added interval name tooltip to guitar frets
- Added interval name tooltip to Piano keys