### PR TITLE
#79 Fix broken scales

### DIFF
--- a/src/components/CircleOfFifths/utils/getModeOffset.ts
+++ b/src/components/CircleOfFifths/utils/getModeOffset.ts
@@ -29,6 +29,6 @@ export default function getModeOffset(mode: string) {
     case 'locrian':
       return diminishedOffset;
     default:
-      throw new Error(`Cannot determine circle of fifths offset due to unexpected mode: ${mode}`);
+      return 0;
   }
 }

--- a/src/components/CircleOfFifths/utils/getModeOffset.ts
+++ b/src/components/CircleOfFifths/utils/getModeOffset.ts
@@ -13,6 +13,7 @@ export default function getModeOffset(mode: string) {
   switch (mode) {
     // Major modes
     case 'ionian':
+    case 'major':
       return majorOffset;
     case 'lydian':
       return majorOffset + fourthOffset;
@@ -20,6 +21,7 @@ export default function getModeOffset(mode: string) {
       return majorOffset + fifthOffset;
     // Minor modes
     case 'aeolian':
+    case 'minor':
       return minorOffset;
     case 'dorian':
       return minorOffset + fourthOffset;


### PR DESCRIPTION
# #79 Fix broken scales

Fixes a bug where changing scales would cause notes and chords to stop highlighting

## Changes

- Fixed changing scale breaking highlighted notes and chords
- Handled major and minor pentatonic modes highlighting for circle of fifths

