### PR TITLE
#83 Fix add note input

### DIFF
--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -24,7 +24,7 @@
 <button
   class="fret"
   title={getHighlightedNote(note)?.name}
-  on:click={() => selectedNote.set(note)}
+  on:click={() => selectedNote.select(note)}
   use:tooltip={{ text: getIntervalName(note) }}
 >
   <div

--- a/src/components/Piano/Piano.svelte
+++ b/src/components/Piano/Piano.svelte
@@ -38,7 +38,7 @@
     <div class="white-keys">
       {#each whiteKeys as note}
         <button class="white-keys__key"
-          on:click={() => selectedNote.set(note)}
+          on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
           class:white-keys__key--selected={$selectedNote?.value === note}
         >
@@ -55,7 +55,7 @@
     <div class="black-keys">
       {#each blackKeys as note}
         <button class="black-keys__key"
-          on:click={() => selectedNote.set(note)}
+          on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
           class:black-keys__key--selected={$selectedNote?.value === note}
         >

--- a/src/components/ScaleConfig/ScaleConfig.svelte
+++ b/src/components/ScaleConfig/ScaleConfig.svelte
@@ -16,17 +16,32 @@
   $: $highlightedNotes = getHighlightedNotes($root, scalePattern);
   $: selectedNoteIsHighlighted = $highlightedNotes.some(({ value }) => value === $selectedNote?.value);
   
-  function highlightNote(note: SelectedNote) {
-    const noteIndex = $highlightedNotes.findIndex(highlightedNote => highlightedNote.value === note.value);
-    const noteIsAlreadyHighlighted = noteIndex > -1;
-    if (!noteIsAlreadyHighlighted) {
-      $highlightedNotes = [...$highlightedNotes, note];
-    } else {
-      $highlightedNotes = [
-        ...$highlightedNotes.slice(0, noteIndex),
-        ...$highlightedNotes.slice(noteIndex + 1)
-      ];
-    }
+  function addToHighlightedNotes(note: SelectedNote) {
+    $highlightedNotes = [...$highlightedNotes, note];
+    selectedNote.reset();
+  }
+
+  function updateInHighlightedNote(note: SelectedNote) {
+    const noteIndex = $highlightedNotes.findIndex(highlightedNote => (
+      highlightedNote.value === note.value
+    ));
+    $highlightedNotes = [
+      ...$highlightedNotes.slice(0, noteIndex),
+      note,
+      ...$highlightedNotes.slice(noteIndex + 1)
+    ];
+    selectedNote.reset();
+  }
+
+  function removeFromHighlightedNotes(note: SelectedNote) {
+    const noteIndex = $highlightedNotes.findIndex(highlightedNote => (
+      highlightedNote.value === note.value
+    ));
+    $highlightedNotes = [
+      ...$highlightedNotes.slice(0, noteIndex),
+      ...$highlightedNotes.slice(noteIndex + 1)
+    ];
+    selectedNote.reset();
   }
 </script>
 
@@ -90,9 +105,18 @@
           <input type="text" bind:value={$selectedNote.name} />
         </label>
       </div>
-      <button on:click={() => $selectedNote && highlightNote($selectedNote)}>
-        {selectedNoteIsHighlighted ? 'Remove' : 'Add'}
-      </button>
+      {#if !selectedNoteIsHighlighted}
+        <button on:click={() => $selectedNote && addToHighlightedNotes($selectedNote)}>
+          Add
+        </button>
+      {:else}
+        <button on:click={() => $selectedNote && updateInHighlightedNote($selectedNote)}>
+          Update
+        </button>
+        <button on:click={() => $selectedNote && removeFromHighlightedNotes($selectedNote)}>
+          Remove
+        </button>
+      {/if}
     {/if}
   </div>
 </div>

--- a/src/stores/selectedNote.ts
+++ b/src/stores/selectedNote.ts
@@ -6,15 +6,16 @@ function createSelectedNote() {
 
   return {
     subscribe,
-    set: (value: string) => update((currentSelection) => (
-      currentSelection?.value === value
+    select: (value: string) => update((currentSelection) => {
+      return currentSelection?.value === value
         ? null
         : {
           value,
           name: '',
           color: '#76a0ff'
-        }
-    )),
+        };
+    }),
+    set,
     reset: () => set(null)
   };
 }

--- a/src/stores/selectedNote.ts
+++ b/src/stores/selectedNote.ts
@@ -1,18 +1,29 @@
 import { writable } from 'svelte/store';
+import { highlightedNotes as highlightedNotesStore } from '@/stores';
 import type { SelectedNote } from '@/types';
 
 function createSelectedNote() {
   const { set, subscribe, update } = writable<SelectedNote | null>(null);
 
+  let highlightedNotes: SelectedNote[];
+
+  highlightedNotesStore.subscribe((value) => {
+    highlightedNotes = value;
+  });
+
   return {
     subscribe,
     select: (value: string) => update((currentSelection) => {
+      const {
+        name = '',
+        color = '#76a0ff'
+      } = highlightedNotes.find(note => note.value === value) ?? {};
       return currentSelection?.value === value
         ? null
         : {
           value,
-          name: '',
-          color: '#76a0ff'
+          name,
+          color
         };
     }),
     set,


### PR DESCRIPTION
# #83 Fix add note input

Fixes a bug where selected notes could not be altered in name and colour, amongst other changes

## Notes

- Saw this as an opportunity to fix up some of the selected note functionality, so I added some enhancements as well

## Changes

- Fixed overwriting store set method
- Set scale config to prefill with current note settings if available
- Added update functionality to selected notes