### PR TITLE
#81 Add component unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/svelte": "^5.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@tsconfig/svelte": "^5.0.2",
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^6.20.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "devDependencies": {
     "@stylistic/eslint-plugin": "^1.5.4",
     "@sveltejs/vite-plugin-svelte": "^3.0.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/svelte": "^5.0.1",
     "@tsconfig/svelte": "^5.0.2",
     "@types/node": "^20.11.20",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -24,6 +26,7 @@
     "@vitest/coverage-v8": "^1.2.2",
     "eslint": "^8.56.0",
     "eslint-plugin-svelte": "^2.35.1",
+    "jsdom": "^24.0.0",
     "sass": "^1.69.7",
     "svelte": "^4.2.8",
     "svelte-check": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ devDependencies:
   '@sveltejs/vite-plugin-svelte':
     specifier: ^3.0.1
     version: 3.0.1(svelte@4.2.8)(vite@5.0.8)
+  '@testing-library/jest-dom':
+    specifier: ^6.4.2
+    version: 6.4.2(vitest@1.2.2)
+  '@testing-library/svelte':
+    specifier: ^5.0.1
+    version: 5.0.1(svelte@4.2.8)
   '@tsconfig/svelte':
     specifier: ^5.0.2
     version: 5.0.2
@@ -32,6 +38,9 @@ devDependencies:
   eslint-plugin-svelte:
     specifier: ^2.35.1
     version: 2.35.1(eslint@8.56.0)(svelte@4.2.8)
+  jsdom:
+    specifier: ^24.0.0
+    version: 24.0.0
   sass:
     specifier: ^1.69.7
     version: 1.69.7
@@ -52,7 +61,7 @@ devDependencies:
     version: 5.0.8(@types/node@20.11.20)(sass@1.69.7)
   vitest:
     specifier: ^1.2.2
-    version: 1.2.2(@types/node@20.11.20)(sass@1.69.7)
+    version: 1.2.2(@types/node@20.11.20)(jsdom@24.0.0)(sass@1.69.7)
 
 packages:
 
@@ -61,12 +70,24 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /@adobe/css-tools@4.3.3:
+    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
+    dev: true
+
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
+    dev: true
+
+  /@babel/code-frame@7.24.2:
+    resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.24.2
+      picocolors: 1.0.0
     dev: true
 
   /@babel/helper-string-parser@7.23.4:
@@ -79,12 +100,29 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/highlight@7.24.2:
+    resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.20
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+      picocolors: 1.0.0
+    dev: true
+
   /@babel/parser@7.23.9:
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.23.9
+    dev: true
+
+  /@babel/runtime@7.24.4:
+    resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
     dev: true
 
   /@babel/types@7.23.9:
@@ -637,8 +675,68 @@ packages:
       - supports-color
     dev: true
 
+  /@testing-library/dom@9.3.4:
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/code-frame': 7.24.2
+      '@babel/runtime': 7.24.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+    dev: true
+
+  /@testing-library/jest-dom@6.4.2(vitest@1.2.2):
+    resolution: {integrity: sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@jest/globals': '>= 28'
+      '@types/bun': latest
+      '@types/jest': '>= 28'
+      jest: '>= 28'
+      vitest: '>= 0.32'
+    peerDependenciesMeta:
+      '@jest/globals':
+        optional: true
+      '@types/bun':
+        optional: true
+      '@types/jest':
+        optional: true
+      jest:
+        optional: true
+      vitest:
+        optional: true
+    dependencies:
+      '@adobe/css-tools': 4.3.3
+      '@babel/runtime': 7.24.4
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+      vitest: 1.2.2(@types/node@20.11.20)(jsdom@24.0.0)(sass@1.69.7)
+    dev: true
+
+  /@testing-library/svelte@5.0.1(svelte@4.2.8):
+    resolution: {integrity: sha512-UP/n37BVDMLp9Ntlr7sYQ2jwOeFZR8bquesk9sCSjBGv/YmxuKrUuP+98KNGvEkW2uAep8rFKHgs9nRUJ40yXw==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5
+    dependencies:
+      '@testing-library/dom': 9.3.4
+      svelte: 4.2.8
+    dev: true
+
   /@tsconfig/svelte@5.0.2:
     resolution: {integrity: sha512-BRbo1fOtyVbhfLyuCWw6wAWp+U8UQle+ZXu84MYYWzYSEB28dyfnRBIE99eoG+qdAC0po6L2ScIEivcT07UaMA==}
+    dev: true
+
+  /@types/aria-query@5.0.4:
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
     dev: true
 
   /@types/estree@1.0.5:
@@ -821,7 +919,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.2.2(@types/node@20.11.20)(sass@1.69.7)
+      vitest: 1.2.2(@types/node@20.11.20)(jsdom@24.0.0)(sass@1.69.7)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -884,6 +982,15 @@ packages:
     hasBin: true
     dev: true
 
+  /agent-base@7.1.1:
+    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -896,6 +1003,13 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
     dev: true
 
   /ansi-styles@4.3.0:
@@ -922,10 +1036,24 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
+    dependencies:
+      deep-equal: 2.2.3
+    dev: true
+
   /aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
     dependencies:
       dequal: 2.0.3
+    dev: true
+
+  /array-buffer-byte-length@1.0.1:
+    resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      is-array-buffer: 3.0.4
     dev: true
 
   /array-union@2.1.0:
@@ -935,6 +1063,17 @@ packages:
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+    dev: true
+
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
+  /available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      possible-typed-array-names: 1.0.0
     dev: true
 
   /axobject-query@3.2.1:
@@ -981,6 +1120,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.2
+    dev: true
+
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -997,6 +1147,23 @@ packages:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
+    dev: true
+
+  /chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
     dev: true
 
   /chalk@4.1.2:
@@ -1038,6 +1205,12 @@ packages:
       periscopic: 3.1.0
     dev: true
 
+  /color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1045,8 +1218,19 @@ packages:
       color-name: 1.1.4
     dev: true
 
+  /color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
     dev: true
 
   /concat-map@0.0.1:
@@ -1074,10 +1258,29 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: true
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /cssstyle@4.0.1:
+    resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      rrweb-cssom: 0.6.0
+    dev: true
+
+  /data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.0.0
     dev: true
 
   /debug@4.3.4:
@@ -1092,11 +1295,39 @@ packages:
       ms: 2.1.2
     dev: true
 
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+    dev: true
+
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
     dependencies:
       type-detect: 4.0.8
+    dev: true
+
+  /deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.1
+      call-bind: 1.0.7
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.2.4
+      is-arguments: 1.1.1
+      is-array-buffer: 3.0.4
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.3
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.5
+      regexp.prototype.flags: 1.5.2
+      side-channel: 1.0.6
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.2
+      which-typed-array: 1.1.15
     dev: true
 
   /deep-is@0.1.4:
@@ -1106,6 +1337,29 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+    dev: true
+
+  /define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+    dev: true
+
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /dequal@2.0.3:
@@ -1135,6 +1389,45 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: true
+
+  /dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+    dev: true
+
+  /dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+    dev: true
+
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: true
+
+  /es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+      has-symbols: 1.0.3
+      is-arguments: 1.1.1
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.0.7
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.0.0
     dev: true
 
   /es6-promise@3.3.1:
@@ -1170,6 +1463,11 @@ packages:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
+    dev: true
+
+  /escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
     dev: true
 
   /escape-string-regexp@4.0.0:
@@ -1393,6 +1691,21 @@ packages:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
     dev: true
 
+  /for-each@0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
+    dev: true
+
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -1405,8 +1718,27 @@ packages:
     dev: true
     optional: true
 
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: true
+
+  /functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+    dev: true
+
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
+  /get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
     dev: true
 
   /get-stream@8.0.1:
@@ -1458,6 +1790,12 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: true
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -1466,18 +1804,91 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /has-bigints@1.0.2:
+    resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+    dev: true
+
+  /has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+    dev: true
+
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    dependencies:
+      es-define-property: 1.0.0
+    dev: true
+
+  /has-proto@1.0.3:
+    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.0.3
+    dev: true
+
+  /hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: true
+
+  /html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-encoding: 3.1.1
     dev: true
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /https-proxy-agent@7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+    dev: true
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: true
 
   /ignore@5.3.0:
@@ -1502,6 +1913,11 @@ packages:
     engines: {node: '>=0.8.19'}
     dev: true
 
+  /indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+    dev: true
+
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -1513,11 +1929,62 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
 
+  /internal-slot@1.0.7:
+    resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.0.6
+    dev: true
+
+  /is-arguments@1.1.1:
+    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+    dev: true
+
+  /is-array-buffer@3.0.4:
+    resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /is-bigint@1.0.4:
+    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
+    dependencies:
+      has-bigints: 1.0.2
+    dev: true
+
   /is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
+    dev: true
+
+  /is-boolean-object@1.1.2:
+    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+    dev: true
+
+  /is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-date-object@1.0.5:
+    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.2
     dev: true
 
   /is-extglob@2.1.1:
@@ -1532,6 +1999,18 @@ packages:
       is-extglob: 2.1.1
     dev: true
 
+  /is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-number-object@1.0.7:
+    resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.2
+    dev: true
+
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -1542,15 +2021,70 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: true
+
   /is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
     dependencies:
       '@types/estree': 1.0.5
     dev: true
 
+  /is-regex@1.1.4:
+    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+    dev: true
+
+  /is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-shared-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+    dev: true
+
   /is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
+  /is-string@1.0.7:
+    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.2
+    dev: true
+
+  /is-symbol@1.0.4:
+    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-symbols: 1.0.3
+    dev: true
+
+  /is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /is-weakset@2.0.3:
+    resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      get-intrinsic: 1.2.4
+    dev: true
+
+  /isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
 
   /isexe@2.0.0:
@@ -1590,11 +2124,51 @@ packages:
       istanbul-lib-report: 3.0.1
     dev: true
 
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: true
+
+  /jsdom@24.0.0:
+    resolution: {integrity: sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      cssstyle: 4.0.1
+      data-urls: 5.0.0
+      decimal.js: 10.4.3
+      form-data: 4.0.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.4
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.9
+      parse5: 7.1.2
+      rrweb-cssom: 0.6.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.3
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.0.0
+      ws: 8.16.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /json-buffer@3.0.1:
@@ -1664,6 +2238,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
     dependencies:
@@ -1675,6 +2253,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
     dev: true
 
   /magic-string@0.30.5:
@@ -1718,6 +2301,18 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+    dev: true
+
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
     dev: true
 
   /mimic-fn@4.0.0:
@@ -1794,6 +2389,37 @@ packages:
       path-key: 4.0.0
     dev: true
 
+  /nwsapi@2.2.9:
+    resolution: {integrity: sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg==}
+    dev: true
+
+  /object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+    dev: true
+
+  /object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+    dev: true
+
+  /object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /object.assign@4.1.5:
+    resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      has-symbols: 1.0.3
+      object-keys: 1.1.1
+    dev: true
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
@@ -1845,6 +2471,12 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
+
+  /parse5@7.1.2:
+    resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
+    dependencies:
+      entities: 4.5.0
     dev: true
 
   /path-exists@4.0.0:
@@ -1905,6 +2537,11 @@ packages:
       pathe: 1.1.2
     dev: true
 
+  /possible-typed-array-names@1.0.0:
+    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /postcss-load-config@3.1.4(postcss@8.4.33):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -1962,6 +2599,15 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+    dev: true
+
   /pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1971,13 +2617,25 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /psl@1.9.0:
+    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
     dev: true
 
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+    dev: true
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
   /react-is@18.2.0:
@@ -1989,6 +2647,32 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+    dev: true
+
+  /redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    dev: true
+
+  /regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+    dev: true
+
+  /regexp.prototype.flags@1.5.2:
+    resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      set-function-name: 2.0.2
+    dev: true
+
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
     dev: true
 
   /resolve-from@4.0.0:
@@ -2038,6 +2722,10 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -2049,6 +2737,10 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mri: 1.2.0
+    dev: true
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
   /sander@0.5.1:
@@ -2070,12 +2762,41 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: true
+
   /semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
+
+  /set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+    dev: true
+
+  /set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
     dev: true
 
   /shebang-command@2.0.0:
@@ -2088,6 +2809,16 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
+
+  /side-channel@1.0.6:
+    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+      object-inspect: 1.13.1
     dev: true
 
   /siginfo@2.0.0:
@@ -2132,6 +2863,13 @@ packages:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
 
+  /stop-iteration-iterator@1.0.0:
+    resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      internal-slot: 1.0.7
+    dev: true
+
   /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2160,6 +2898,13 @@ packages:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
       acorn: 8.11.3
+    dev: true
+
+  /supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
     dev: true
 
   /supports-color@7.2.0:
@@ -2290,6 +3035,10 @@ packages:
       periscopic: 3.1.0
     dev: true
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: true
+
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -2327,6 +3076,23 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
+
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
+    engines: {node: '>=6'}
+    dependencies:
+      psl: 1.9.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+    dev: true
+
+  /tr46@5.0.0:
+    resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
+    engines: {node: '>=18'}
+    dependencies:
+      punycode: 2.3.1
     dev: true
 
   /ts-api-utils@1.0.3(typescript@5.2.2):
@@ -2373,10 +3139,22 @@ packages:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+    dev: true
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
     dev: true
 
   /util-deprecate@1.0.2:
@@ -2461,7 +3239,7 @@ packages:
       vite: 5.0.8(@types/node@20.11.20)(sass@1.69.7)
     dev: true
 
-  /vitest@1.2.2(@types/node@20.11.20)(sass@1.69.7):
+  /vitest@1.2.2(@types/node@20.11.20)(jsdom@24.0.0)(sass@1.69.7):
     resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -2497,6 +3275,7 @@ packages:
       chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
+      jsdom: 24.0.0
       local-pkg: 0.5.0
       magic-string: 0.30.5
       pathe: 1.1.2
@@ -2518,6 +3297,69 @@ packages:
       - terser
     dev: true
 
+  /w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+    dependencies:
+      xml-name-validator: 5.0.0
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: true
+
+  /whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /whatwg-url@14.0.0:
+    resolution: {integrity: sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==}
+    engines: {node: '>=18'}
+    dependencies:
+      tr46: 5.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
+  /which-boxed-primitive@1.0.2:
+    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
+    dependencies:
+      is-bigint: 1.0.4
+      is-boolean-object: 1.1.2
+      is-number-object: 1.0.7
+      is-string: 1.0.7
+      is-symbol: 1.0.4
+    dev: true
+
+  /which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.3
+    dev: true
+
+  /which-typed-array@1.1.15:
+    resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.7
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.2
+    dev: true
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2537,6 +3379,28 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true
+
+  /xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: true
 
   /yallist@4.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ devDependencies:
   '@testing-library/svelte':
     specifier: ^5.0.1
     version: 5.0.1(svelte@4.2.8)
+  '@testing-library/user-event':
+    specifier: ^14.5.2
+    version: 14.5.2(@testing-library/dom@9.3.4)
   '@tsconfig/svelte':
     specifier: ^5.0.2
     version: 5.0.2
@@ -729,6 +732,15 @@ packages:
     dependencies:
       '@testing-library/dom': 9.3.4
       svelte: 4.2.8
+    dev: true
+
+  /@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4):
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 9.3.4
     dev: true
 
   /@tsconfig/svelte@5.0.2:

--- a/src/components/CircleOfFifths/CircleOfFifths.svelte
+++ b/src/components/CircleOfFifths/CircleOfFifths.svelte
@@ -66,9 +66,18 @@
   });
 </script>
 
-<svg viewBox="0 0 {size} {size}" {width} {height}>
+<svg
+  viewBox="0 0 {size} {size}"
+  {width}
+  {height}
+  role="graphics-document"
+>
   {#each fifthsShapes as { isHighlighted, name, path, textCoordinates }}
-  <g>
+  <g
+    role="gridcell"
+    aria-labelledby={`circle-of-fifths-chord-${name}`}
+    aria-selected={isHighlighted}
+  >
     <path
       d={path}
       class="segment"
@@ -80,6 +89,7 @@
       x={textCoordinates.x}
       y={textCoordinates.y}
       font-weight={isHighlighted ? 'bold' : 'normal'}
+      id={`circle-of-fifths-chord-${name}`}
     >
       {name}
     </text>

--- a/src/components/Dropdown/Dropdown.svelte
+++ b/src/components/Dropdown/Dropdown.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  export let label: string;
+  export let options: string[] = [];
+  export let value: string = options[0];
+</script>
+
+<label>
+  <span>
+    {label}
+  </span>
+  <select bind:value={value}>
+    {#each options as option}
+      <option value={option}>
+        {option}
+      </option>
+    {/each}
+  </select>
+</label>

--- a/src/components/Dropdown/index.ts
+++ b/src/components/Dropdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Dropdown.svelte';

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -9,11 +9,13 @@
 
 </script>
 
-<div>
+<!-- TODO: Replace test id with something accessible -->
+<div data-testId="guitar">
   <div class="guitar">
     <div class="fret-markers">
       {#each { length: numberOfFrets + 1 } as _, i}
-        <div class="fret-markers__item">
+        <!-- TODO: Replace test id with something accessible -->
+        <div class="fret-markers__item" data-testId="fret-marker">
           <div
             class="fret-markers__number"
             class:fret-markers__number--highlighted={fretMarkers.includes(i)}

--- a/src/components/Guitar/subcomponents/Config/Config.svelte
+++ b/src/components/Guitar/subcomponents/Config/Config.svelte
@@ -34,7 +34,7 @@
 
 </script>
 
-<form>
+<form name="Guitar Config">
   <label>
     <span>Number of Strings:</span>
     <input

--- a/src/components/Guitar/subcomponents/Fret/Fret.scss
+++ b/src/components/Guitar/subcomponents/Fret/Fret.scss
@@ -38,17 +38,22 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 50%;
+  }
+
+  &[aria-selected="true"] > &__indicator {
     background-color: rgb(255, 255, 255);
     color: var(--text-dark-contrast-locked);
     font-weight: 700;
+  }
 
-    &--selected {
-      border: var(--text-light-low-emphasis-locked) 0.25rem solid;
-      background-color: var(--text-light-disabled-locked);
+  &[aria-current="location"] > &__indicator {
+    border: var(--text-light-low-emphasis-locked) 0.25rem solid;
+    background-color: var(--text-light-disabled-locked);
+    color: var(--text-dark-contrast-locked);
+    font-weight: 700;
 
-      :global([data-theme="dark"]) & {
-        color: var(--text-dark-contrast);
-      }
+    :global([data-theme="dark"]) & {
+      color: var(--text-dark-contrast);
     }
   }
 }

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -21,11 +21,15 @@
   );
 </script>
 
+<!-- TODO: aria-selected should be set to <td /> once Guitar, String, and Fret are an accessible grid -->
+<!-- svelte-ignore a11y-role-supports-aria-props -->
 <button
   class="fret"
   title={getHighlightedNote(note)?.name}
   on:click={() => selectedNote.select(note)}
   use:tooltip={{ text: getIntervalName(note) }}
+  aria-current={isSelected(note) && 'location'}
+  aria-selected={isHighlighted(note) ? 'true' : 'false'}
 >
   <div
     class:fret__indicator={isHighlighted(note) || isSelected(note)}

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -32,8 +32,7 @@
   aria-selected={isHighlighted(note) ? 'true' : 'false'}
 >
   <div
-    class:fret__indicator={isHighlighted(note) || isSelected(note)}
-    class:fret__indicator--selected={isSelected(note)}
+    class="fret__indicator"
     style={isHighlighted(note) ? `background-color: ${getHighlightedNote(note)?.color};` : undefined}
   >
     {note}

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -8,7 +8,8 @@
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
 
-<div class="string">
+<!-- TODO: Replace testId with better role -->
+<div class="string" data-testId="guitar-string">
   {#each notes as note}
     <Fret {note} />
   {/each}

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -5,25 +5,6 @@
   background-color: var(--background-light);
 }
 
-.menu {
-  all: unset;
-  position: absolute;
-  left: 0;
-  top: 3rem;
-  bottom: 0;
-  box-sizing: border-box;
-  padding: 1rem;
-  width: 20rem;
-  border-right: 0.25rem solid var(--text-dark-contrast);
-  background-color: var(--background-light);
-  transform: translateX(-100%);
-  transition: transform 250ms;
-
-  &--open {
-    transform: translateX(0);
-  }
-}
-
 .body {
   flex-grow: 1;
 }

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -5,24 +5,6 @@
   background-color: var(--background-light);
 }
 
-.header {
-  z-index: 2;
-  display: grid;
-  align-items: center;
-  justify-content: space-between;
-  grid-template-columns: 5rem auto 5rem;
-  height: 3rem;
-  background-color: var(--background-light);
-
-  &__button {
-    all: unset;
-    border: solid 0.25rem white;
-    padding: 0 1rem;
-    height: 100%;
-    cursor: pointer;
-  }
-}
-
 .menu {
   all: unset;
   position: absolute;

--- a/src/components/Layout/Layout.svelte
+++ b/src/components/Layout/Layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Dropdown } from '@/components';
   import { Header } from './subcomponents';
 
   let menuIsOpen: boolean = false;
@@ -61,22 +62,15 @@
     class="menu"
     class:menu--open={menuIsOpen}
   >
-    <label>
-      <span>
-        Theme
-      </span>
-      <select bind:value={theme}>
-        <option value="system">
-          System
-        </option>
-        <option value="light">
-          Light
-        </option>
-        <option value="dark">
-          Dark
-        </option>
-      </select>
-    </label>
+    <Dropdown
+      label="Theme"
+      options={[
+        'system',
+        'light',
+        'dark'
+      ]}
+      bind:value={theme}
+    />
   </menu>
   <div class="body">
     <slot />

--- a/src/components/Layout/Layout.svelte
+++ b/src/components/Layout/Layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { Header } from './subcomponents';
+
   let menuIsOpen: boolean = false;
   let theme: Theme = getTheme();
 
@@ -53,18 +55,8 @@
   }
 </script>
 
-<div class="container">
-  <header class="header">
-    <button
-      class="header__button"
-      on:click={toggleMenu}
-    >
-      Menu
-    </button>
-    <span>
-      Music
-    </span>
-  </header>
+<div class="container" data-testid="layout">
+  <Header onMenuButtonClick={toggleMenu} />
   <menu
     class="menu"
     class:menu--open={menuIsOpen}

--- a/src/components/Layout/Layout.svelte
+++ b/src/components/Layout/Layout.svelte
@@ -1,55 +1,7 @@
 <script lang="ts">
-  import { Dropdown } from '@/components';
-  import { Header } from './subcomponents';
+  import { Header, Menu } from './subcomponents';
 
   let menuIsOpen: boolean = false;
-  let theme: Theme = getTheme();
-
-  type Theme = 'system' | 'light' | 'dark';
-
-  $: setTheme(theme);
-
-  function getTheme() {
-    const savedTheme = localStorage.getItem('theme');
-
-    switch (savedTheme) {
-      case 'light':
-      case 'dark':
-        return savedTheme;
-      default:
-        return 'system';
-    }
-  }
-
-  function setTheme(theme: string) {
-    switch (theme) {
-      case 'system': {
-        const isDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        
-        if (isDarkTheme) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-        } else {
-          document.documentElement.setAttribute('data-theme', 'light');
-        }
-
-        localStorage.removeItem('theme');
-        break;
-      }
-      case 'light': {
-        document.documentElement.setAttribute('data-theme', 'light');
-        localStorage.setItem('theme', 'light');
-        break;
-      }
-      case 'dark': {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        localStorage.setItem('theme', 'dark');
-        break;
-      }
-      default: {
-        throw new Error(`Unknown theme received: ${theme}`);
-      }
-    }
-  }
 
   function toggleMenu() {
     menuIsOpen = !menuIsOpen;
@@ -58,20 +10,7 @@
 
 <div class="container" data-testid="layout">
   <Header onMenuButtonClick={toggleMenu} />
-  <menu
-    class="menu"
-    class:menu--open={menuIsOpen}
-  >
-    <Dropdown
-      label="Theme"
-      options={[
-        'system',
-        'light',
-        'dark'
-      ]}
-      bind:value={theme}
-    />
-  </menu>
+  <Menu isOpen={menuIsOpen} />
   <div class="body">
     <slot />
   </div>

--- a/src/components/Layout/subcomponents/Header/Header.scss
+++ b/src/components/Layout/subcomponents/Header/Header.scss
@@ -1,0 +1,22 @@
+.container {
+  z-index: 2;
+  display: grid;
+  align-items: center;
+  justify-content: space-between;
+  grid-template-columns: 5rem auto 5rem;
+  height: 3rem;
+  background-color: var(--background-light);
+}
+
+.title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.button {
+  all: unset;
+  border: solid 0.25rem white;
+  padding: 0 1rem;
+  height: 100%;
+  cursor: pointer;
+}

--- a/src/components/Layout/subcomponents/Header/Header.svelte
+++ b/src/components/Layout/subcomponents/Header/Header.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let onMenuButtonClick = () => {};
+</script>
+
+<header class="container">
+  <button
+    class="button"
+    on:click={onMenuButtonClick}
+  >
+    Menu
+  </button>
+  <h1 class="title">
+    Music
+  </h1>
+</header>
+
+<style lang="scss">
+  @import './Header.scss';
+</style>

--- a/src/components/Layout/subcomponents/Header/index.ts
+++ b/src/components/Layout/subcomponents/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header.svelte';

--- a/src/components/Layout/subcomponents/Menu/Menu.scss
+++ b/src/components/Layout/subcomponents/Menu/Menu.scss
@@ -1,0 +1,18 @@
+.container {
+  all: unset;
+  position: absolute;
+  left: 0;
+  top: 3rem;
+  bottom: 0;
+  box-sizing: border-box;
+  padding: 1rem;
+  width: 20rem;
+  border-right: 0.25rem solid var(--text-dark-contrast);
+  background-color: var(--background-light);
+  transform: translateX(-100%);
+  transition: transform 250ms;
+
+  &--open {
+    transform: translateX(0);
+  }
+}

--- a/src/components/Layout/subcomponents/Menu/Menu.svelte
+++ b/src/components/Layout/subcomponents/Menu/Menu.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { Dropdown } from '@/components';
+  import { getTheme, setTheme } from './utils';
+
+  export let isOpen = false;
+
+  let theme = getTheme();
+
+  $: setTheme(theme);
+</script>
+
+<menu
+  class="container"
+  class:container--open={isOpen}
+>
+  <Dropdown
+    label="Theme"
+    options={[
+      'system',
+      'light',
+      'dark'
+    ]}
+    bind:value={theme}
+  />
+</menu>
+
+<style lang="scss">
+  @import './Menu.scss';
+</style>

--- a/src/components/Layout/subcomponents/Menu/index.ts
+++ b/src/components/Layout/subcomponents/Menu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Menu.svelte';

--- a/src/components/Layout/subcomponents/Menu/utils/getTheme.ts
+++ b/src/components/Layout/subcomponents/Menu/utils/getTheme.ts
@@ -1,0 +1,11 @@
+export default function getTheme() {
+  const savedTheme = localStorage.getItem('theme');
+
+  switch (savedTheme) {
+    case 'light':
+    case 'dark':
+      return savedTheme;
+    default:
+      return 'system';
+  }
+}

--- a/src/components/Layout/subcomponents/Menu/utils/index.ts
+++ b/src/components/Layout/subcomponents/Menu/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getTheme } from './getTheme';

--- a/src/components/Layout/subcomponents/Menu/utils/index.ts
+++ b/src/components/Layout/subcomponents/Menu/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as getTheme } from './getTheme';
+export { default as setTheme } from './setTheme';

--- a/src/components/Layout/subcomponents/Menu/utils/setTheme.ts
+++ b/src/components/Layout/subcomponents/Menu/utils/setTheme.ts
@@ -1,0 +1,29 @@
+export default function setTheme(theme: string) {
+  switch (theme) {
+    case 'system': {
+      const isDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      
+      if (isDarkTheme) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      } else {
+        document.documentElement.setAttribute('data-theme', 'light');
+      }
+
+      localStorage.removeItem('theme');
+      break;
+    }
+    case 'light': {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+      break;
+    }
+    case 'dark': {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+      break;
+    }
+    default: {
+      throw new Error(`Unknown theme received: ${theme}`);
+    }
+  }
+}

--- a/src/components/Layout/subcomponents/index.ts
+++ b/src/components/Layout/subcomponents/index.ts
@@ -1,0 +1,1 @@
+export { default as Header } from './Header';

--- a/src/components/Layout/subcomponents/index.ts
+++ b/src/components/Layout/subcomponents/index.ts
@@ -1,1 +1,2 @@
 export { default as Header } from './Header';
+export { default as Menu } from './Menu';

--- a/src/components/Piano/Piano.scss
+++ b/src/components/Piano/Piano.scss
@@ -30,107 +30,107 @@
 
 .white-keys {
   display: flex;
+}
   
-  &__key {
-    @extend %key;
-    position: relative;
-    width: var(--white-key-width);
-    height: 15rem;
-    background-color: white;
+.white-key {
+  @extend %key;
+  position: relative;
+  width: var(--white-key-width);
+  height: 15rem;
+  background-color: white;
 
-    &:not(:last-child) {
-      border-right: none;
-    }
+  &:not(:last-child) {
+    border-right: none;
+  }
+
+  :global([data-theme="dark"]) & {
+    border-color: white;
+    background-color: rgb(60, 60, 60);
+  }
+
+  &:hover {
+    background-color: hsl(from orange h s 90);
+    border-color: orange;
 
     :global([data-theme="dark"]) & {
-      border-color: white;
-      background-color: rgb(60, 60, 60);
+      background-color: hsl(from orange h 70 20) !important;
     }
+  }
 
-    &:hover {
-      background-color: hsl(from orange h s 90);
-      border-color: orange;
-
-      :global([data-theme="dark"]) & {
-        background-color: hsl(from orange h 70 20) !important;
-      }
-    }
-
-    &--selected {
-      background-color: hsl(from orange h s 75) !important;
-    }
+  &[aria-current="location"] {
+    background-color: hsl(from orange h s 75) !important;
   }
 
   &__indicator {
     @extend %indicator;
     color: var(--text-dark-low-emphasis);
+  }
 
-    &--highlighted {
-      color: var(--text-dark-contrast-locked);
-      font-weight: 700;
+  &[aria-selected="true"] > &__indicator {
+    color: var(--text-dark-contrast-locked);
+    font-weight: 700;
 
-      :global([data-theme="light"]) & {
-        box-shadow: rgba(0, 0, 0, 1) 0 0 0.25rem;
-      }
+    :global([data-theme="light"]) & {
+      box-shadow: rgba(0, 0, 0, 1) 0 0 0.25rem;
     }
   }
 }
 
-.black-keys {
+.black-key {
   position: absolute;
   top: 0;
   display: flex;
   justify-content: center;
+}
 
-  &__key {
-    @extend %key;
-    position: absolute;
-    width: var(--black-key-width);
-    height: 10rem;
-    background-color: black;
+.black-key {
+  @extend %key;
+  position: absolute;
+  width: var(--black-key-width);
+  height: 10rem;
+  background-color: black;
 
-    &:nth-child(1) {
-      left: calc(var(--white-key-width) - (var(--black-key-width) / 2));
-    }
+  &:nth-child(1) {
+    left: calc(var(--white-key-width) - (var(--black-key-width) / 2));
+  }
 
-    &:nth-child(2) {
-      left: calc((var(--white-key-width) * 2) - (var(--black-key-width) / 2));
-    }
+  &:nth-child(2) {
+    left: calc((var(--white-key-width) * 2) - (var(--black-key-width) / 2));
+  }
 
-    &:nth-child(3) {
-      left: calc((var(--white-key-width) * 4) - (var(--black-key-width) / 2));
-    }
+  &:nth-child(3) {
+    left: calc((var(--white-key-width) * 4) - (var(--black-key-width) / 2));
+  }
 
-    &:nth-child(4) {
-      left: calc((var(--white-key-width) * 5) - (var(--black-key-width) / 2));
+  &:nth-child(4) {
+    left: calc((var(--white-key-width) * 5) - (var(--black-key-width) / 2));
 
-    }
+  }
 
-    &:nth-child(5) {
-      left: calc((var(--white-key-width) * 6) - (var(--black-key-width) / 2));
-    }
+  &:nth-child(5) {
+    left: calc((var(--white-key-width) * 6) - (var(--black-key-width) / 2));
+  }
 
-    :global([data-theme="dark"]) & {
-      border: 0.125rem solid white;
-    }
+  :global([data-theme="dark"]) & {
+    border: 0.125rem solid white;
+  }
 
-    &:hover {
-      background-color: hsl(from orange h s 10);
-      border-color: orange;
-    }
+  &:hover {
+    background-color: hsl(from orange h s 10);
+    border-color: orange;
+  }
 
-    &--selected {
-      background-color: hsl(from orange h s 25) !important;
-    }
+  &[aria-current="location"] {
+    background-color: hsl(from orange h s 25) !important;
   }
 
   &__indicator {
     @extend %indicator;
     color: var(--text-light-low-emphasis-locked);
+  }
 
-    &--highlighted {
-      color: var(--text-dark-contrast-locked);
-      font-weight: 700;
-    }
+  &[aria-selected="true"] > &__indicator {
+    color: var(--text-dark-contrast-locked);
+    font-weight: 700;
   }
 }

--- a/src/components/Piano/Piano.svelte
+++ b/src/components/Piano/Piano.svelte
@@ -20,6 +20,10 @@
     'A#'
   ];
 
+  $: isSelected = (note: string) => (
+    $selectedNote?.value === note
+  );
+
   $: isHighlighted = (note: string) => (
     $highlightedNotes.some(({ value }) => value === note)
   );
@@ -43,8 +47,8 @@
         <button class="white-key"
           on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
-          aria-selected={isHighlighted(note)}
-          aria-current={$selectedNote?.value === note ? 'location' : 'false'}
+          aria-current={isSelected(note) && 'location'}
+          aria-selected={isHighlighted(note) ? 'true' : 'false'}
         >
           <div
             class="white-key__indicator"
@@ -62,8 +66,8 @@
         <button class="black-key"
           on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
-          aria-selected={isHighlighted(note)}
-          aria-current={$selectedNote?.value === note ? 'location' : 'false'}
+          aria-current={isSelected(note) && 'location'}
+          aria-selected={isHighlighted(note) ? 'true' : 'false'}
         >
           <div
             class="black-key__indicator"

--- a/src/components/Piano/Piano.svelte
+++ b/src/components/Piano/Piano.svelte
@@ -33,18 +33,21 @@
   );
 </script>
 
-<div class="container">
+<!-- TODO: replace testId with accessible role -->
+<div class="container" data-testId="piano">
   <div class="piano">
     <div class="white-keys">
       {#each whiteKeys as note}
-        <button class="white-keys__key"
+        <!-- TODO: aria-selected should be set to <td /> once Piano is an accessible grid -->
+        <!-- svelte-ignore a11y-role-supports-aria-props -->
+        <button class="white-key"
           on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
-          class:white-keys__key--selected={$selectedNote?.value === note}
+          aria-selected={isHighlighted(note)}
+          aria-current={$selectedNote?.value === note ? 'location' : 'false'}
         >
           <div
-            class="white-keys__indicator"
-            class:white-keys__indicator--highlighted={isHighlighted(note)}
+            class="white-key__indicator"
             style={isHighlighted(note) ? `background-color: ${getHighlightedNote(note)?.color};` : undefined}
           >
             {note}
@@ -54,14 +57,16 @@
     </div>
     <div class="black-keys">
       {#each blackKeys as note}
-        <button class="black-keys__key"
+        <!-- TODO: aria-selected should be set to <td /> once Piano is an accessible grid -->
+        <!-- svelte-ignore a11y-role-supports-aria-props -->
+        <button class="black-key"
           on:click={() => selectedNote.select(note)}
           use:tooltip={{ text: getIntervalName(note) }}
-          class:black-keys__key--selected={$selectedNote?.value === note}
+          aria-selected={isHighlighted(note)}
+          aria-current={$selectedNote?.value === note ? 'location' : 'false'}
         >
           <div
-            class="black-keys__indicator"
-            class:black-keys__indicator--highlighted={isHighlighted(note)}
+            class="black-key__indicator"
             style={isHighlighted(note) ? `background-color: ${getHighlightedNote(note)?.color};` : undefined}
           >
             {note}

--- a/src/components/ScaleConfig/ScaleConfig.svelte
+++ b/src/components/ScaleConfig/ScaleConfig.svelte
@@ -45,7 +45,10 @@
   }
 </script>
 
-<div class="container">
+<form
+  class="container"
+  name="scale-config"
+>
   <div>
     <h2>
       The {$root} {$mode} mode of the {scaleName} scale
@@ -119,7 +122,7 @@
       {/if}
     {/if}
   </div>
-</div>
+</form>
 
 <style lang="scss">
   @import './ScaleConfig.scss';

--- a/src/components/Tooltip/Tooltip.svelte
+++ b/src/components/Tooltip/Tooltip.svelte
@@ -8,6 +8,7 @@
   <div
     class="tooltip"
     style="left: {x}px; top: {y}px;"
+    role="tooltip"
   >
     {details}
     <div class="tooltip__tail" />

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { default as CircleOfFifths } from './CircleOfFifths';
+export { default as Dropdown } from './Dropdown';
 export { default as Guitar } from './Guitar';
 export { default as Layout } from './Layout';
 export { default as Piano } from './Piano';

--- a/tests/components/CircleOfFifths/CircleOfFifths.test.ts
+++ b/tests/components/CircleOfFifths/CircleOfFifths.test.ts
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CircleOfFifths } from '@/components';
+
+describe('<CircleOfFifths />', () => {
+  const majorFifths = [
+    'C',
+    'G',
+    'D',
+    'A',
+    'E',
+    'B',
+    'G♭/F♯',
+    'D♭',
+    'A♭',
+    'E♭',
+    'B♭',
+    'F'
+  ];
+
+  const minorFifths = [
+    'a',
+    'e',
+    'b',
+    'f♯',
+    'c♯',
+    'g♯',
+    'e♭/d♯',
+    'b♭',
+    'f',
+    'c',
+    'g',
+    'd'
+  ];
+
+  const diminishedFifths = [
+    'B°',
+    'F♯°',
+    'C♯°',
+    'G♯°',
+    'D♯°',
+    'A♯°',
+    'E♯°',
+    'C°',
+    'G°',
+    'D°',
+    'A°',
+    'E°',
+  ];
+
+  const cScaleDiatonicChords = [
+    'C',
+    'd',
+    'e',
+    'F',
+    'G',
+    'a',
+    'B°'
+  ];
+
+  beforeEach(() => {
+    render(CircleOfFifths);
+  });
+
+  it('Should render', () => {
+    const circleOfFifths = screen.getByRole('graphics-document');
+    expect(circleOfFifths).toBeInTheDocument();
+  });
+
+  it('Should render all major chords', () => {
+    majorFifths.forEach(note => {
+      const chord = screen.getByRole('gridcell', { name: note });
+      expect(chord).toBeInTheDocument();
+    });
+  });
+
+  it('Should render all minor chords', () => {
+    minorFifths.forEach(note => {
+      const chord = screen.getByRole('gridcell', { name: note });
+      expect(chord).toBeInTheDocument();
+    });
+  });
+
+  it('Should render all diminished chords', () => {
+    diminishedFifths.forEach(note => {
+      const chord = screen.getByRole('gridcell', { name: note });
+      expect(chord).toBeInTheDocument();
+    });
+  });
+
+  it('Should highlight chords available in the current diatonic scale', () => {
+    cScaleDiatonicChords.forEach(note => {
+      const chord = screen.getByRole('gridcell', { name: note });
+      expect(chord).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  it('Should not highlight chords not available in the current diatonic scale', () => {
+    [...majorFifths, ...minorFifths, ...diminishedFifths]
+      .filter(note => !cScaleDiatonicChords.includes(note))
+      .forEach(note => {
+        const chord = screen.getByRole('gridcell', { name: note });
+        expect(chord).toHaveAttribute('aria-selected', 'false');
+      });
+  });
+});

--- a/tests/components/Dropdown.test.ts
+++ b/tests/components/Dropdown.test.ts
@@ -22,6 +22,7 @@ describe('<Dropdown />', () => {
 
   it('Should render a label', () => {
     const label = screen.getByLabelText(/Test Dropdown/);
+    expect(label).toBeInTheDocument();
   });
 
   it('Should render a list of options', () => {

--- a/tests/components/Dropdown.test.ts
+++ b/tests/components/Dropdown.test.ts
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Dropdown } from '@/components';
+
+describe('<Dropdown />', () => {
+  beforeEach(() => {
+    render(Dropdown, {
+      label: 'Test Dropdown',
+      options: [
+        'Test Option 01',
+        'Test Option 02',
+        'Test Option 03'
+      ],
+      value: 'Test Option 02'
+    });
+  });
+
+  it('Should render', () => {
+    const dropdown = screen.getByRole('combobox');
+    expect(dropdown).toBeInTheDocument();
+  });
+
+  it('Should render a label', () => {
+    const label = screen.getByLabelText(/Test Dropdown/);
+  });
+
+  it('Should render a list of options', () => {
+    const options = screen.getAllByText(/Test Option/);
+    options.forEach(option => (
+      expect(option).toBeInTheDocument()
+    ));
+  });
+
+  it('Should allow users to set a value', () => {
+    const dropdown = screen.getByRole('combobox');
+    expect(dropdown).toHaveValue('Test Option 02');
+  });
+});

--- a/tests/components/Guitar/Guitar.test.ts
+++ b/tests/components/Guitar/Guitar.test.ts
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Guitar } from '@/components';
+
+describe('<Guitar />', () => {
+  beforeEach(() => {
+    render(Guitar);
+  });
+
+  it('Should render', () => {
+    const guitar = screen.getByTestId('guitar');
+    expect(guitar).toBeInTheDocument();
+  });
+
+  it('Should render fret markers', () => {
+    const fretMarkers = screen.getAllByTestId('fret-marker');
+    expect(fretMarkers.length).toBe(23);
+    fretMarkers.forEach(fretMarker => {
+      expect(fretMarker).toBeInTheDocument();
+    });
+  });
+  
+  it('Should render strings', () => {
+    const strings = screen.getAllByTestId('guitar-string');
+    expect(strings.length).toBe(6);
+    strings.forEach(string => {
+      expect(string).toBeInTheDocument();
+    });
+  });
+
+  it('Should render a configure button', () => {
+    const button = screen.getByRole('button', { name: /Configure/ });
+    expect(button).toBeInTheDocument();
+  });
+
+  describe('When configure button is clicked', () => {
+    beforeEach(async () => {
+      const button = screen.getByRole('button', { name: /Configure/ });
+      await userEvent.click(button);
+    });
+    
+    it('Should render the guitar config', async () => {
+      const config = screen.getByRole('form');
+      expect(config).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/Guitar/subcomponents/Config.test.ts
+++ b/tests/components/Guitar/subcomponents/Config.test.ts
@@ -1,0 +1,88 @@
+import { render, screen, within } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Config } from '@/components/Guitar/subcomponents';
+import { notes } from '@/utils';
+
+describe('<Config />', () => {
+  const numberOfStrings = 6;
+  const numberOfFrets = 12;
+
+  beforeEach(() => {
+    render(Config, {
+      numberOfStrings,
+      numberOfFrets
+    });
+  });
+
+  it('Should render', () => {
+    const config = screen.getByRole('form');
+    expect(config).toBeInTheDocument();
+  });
+
+  it('Should render a control for number of strings', () => {
+    const control = screen.getByRole('spinbutton', { name: /Number of Strings:/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Should set a default number of strings via props', () => {
+    const control = screen.getByRole('spinbutton', { name: /Number of Strings:/ });
+    expect(control).toHaveValue(numberOfStrings);
+  });
+
+  it('Should render a control for number of frets', () => {
+    const control = screen.getByRole('spinbutton', { name: /Number of Frets:/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Should set a default number of frets via props', () => {
+    const control = screen.getByRole('spinbutton', { name: /Number of Frets:/ });
+    expect(control).toHaveValue(numberOfFrets);
+  });
+
+  it('Should render a group of controls for tuning', () => {
+    const group = screen.getByRole('group', { name: /Tuning/ });
+    expect(group).toBeInTheDocument();
+  });
+
+  it('Should render a control for tuning presets', () => {
+    const control = screen.getByRole('combobox', { name: /Presets:/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Should render a control for tuning each string', () => {
+    const labels = ['6th', '5th', '4th', '3rd', '2nd', '1st'];
+    const controls = labels.map(label => (
+      screen.getByRole('combobox', { name: label })
+    ));
+    controls.forEach(control => {
+      expect(control).toBeInTheDocument();
+    });
+  });
+
+  it('Should render an option for every note for tuning controls', () => {
+    const control = screen.getByRole('combobox', { name: '1st' });
+    const options = notes.map(note => (
+      within(control).getByRole('option', { name: note })
+    ));
+    options.forEach(option => {
+      expect(option).toBeInTheDocument();
+    });
+  });
+
+  it('Should render a group of controls for fret markers', () => {
+    const group = screen.getByRole('group', { name: /Fret Markers/ });
+    expect(group).toBeInTheDocument();
+  });
+
+  it('Should render a control for a fret marker for each fret', () => {
+    const labels = new Array(numberOfFrets + 1)
+      .fill(null)
+      .map((_, i) => i.toString());
+    const controls = labels.map(label => (
+      screen.getByRole('checkbox', { name: label })
+    ));
+    controls.forEach(control => {
+      expect(control).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/Guitar/subcomponents/Fret.test.ts
+++ b/tests/components/Guitar/subcomponents/Fret.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { Fret } from '@/components/Guitar/subcomponents';
+import { highlightedNotes, selectedNote } from '@/stores';
+import type { SelectedNote } from '@/types';
+
+vi.mock('@/stores/highlightedNotes', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    default: writable<SelectedNote[]>([])
+  };
+});
+
+describe('<Fret />', () => {
+  describe('Default behaviour', () => {
+    beforeEach(() => {
+      render(Fret, { note: 'C' });
+    });
+  
+    afterEach(() => {
+      selectedNote.reset();
+    });
+  
+    it('Should render', () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toBeInTheDocument();
+    });
+  
+    it('Should set aria-current to false', () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toHaveAttribute('aria-current', 'false');
+    });
+  
+    it('Should set aria-current to location when clicked', async () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toHaveAttribute('aria-current', 'false');
+      await userEvent.click(fret);
+      expect(fret).toHaveAttribute('aria-current', 'location');
+    });
+
+    it('Should set aria-selected to false', () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('When the note is selected', () => {
+    beforeEach(async () => {
+      render(Fret, { note: 'C' });
+      const fret = screen.getByRole('button', { name: /C/ });
+      await userEvent.click(fret);
+    });
+  
+    afterEach(() => {
+      selectedNote.reset();
+    });
+
+    it('Should set aria-current to location', () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toHaveAttribute('aria-current', 'location');
+    });
+  
+    it('Should set aria-current to false when clicked', async () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      await userEvent.click(fret);
+      expect(fret).toHaveAttribute('aria-current', 'false');
+    });
+  });
+
+  describe('When the note is highlighted', () => {
+    beforeEach(() => {
+      render(Fret, { note: 'C' });
+      highlightedNotes.set([
+        {
+          color: '#ff0000',
+          name: 'Root',
+          value: 'C'
+        }
+      ]);
+    });
+  
+    afterEach(() => {
+      selectedNote.reset();
+      vi.clearAllMocks();
+    });
+  
+    it('Should describe the note\'s name', () => {
+      const description = screen.getByTitle('Root');
+      expect(description).toBeInTheDocument();
+    });
+  
+    it('Should display a tooltip when hovered', async () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      await userEvent.hover(fret);
+      const tooltip = screen.getByRole('tooltip', { name: 'Root' });
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    it('Should set aria-selected to true', () => {
+      const fret = screen.getByRole('button', { name: /C/ });
+      expect(fret).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+});

--- a/tests/components/Guitar/subcomponents/String.test.ts
+++ b/tests/components/Guitar/subcomponents/String.test.ts
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { String } from '@/components/Guitar/subcomponents';
+
+describe('<String />', () => {
+  const numberOfFrets = 12;
+  const tuning = 'A';
+
+  beforeEach(() => {
+    render(String, {
+      tuning,
+      numberOfFrets
+    });
+  });
+
+  it('Should render', () => {
+    const string = screen.getByTestId('guitar-string');
+    expect(string).toBeInTheDocument();
+  });
+
+  it('Should start with the correct tuning', () => {
+    const frets = screen.getAllByRole('button');
+    expect(frets[0]).toHaveTextContent(tuning);
+  });
+
+  it('Should render the correct number of frets, including open string', () => {
+    const frets = screen.getAllByRole('button');
+    expect(frets.length).toBe(numberOfFrets + 1);
+  });
+});

--- a/tests/components/Layout/Layout.test.ts
+++ b/tests/components/Layout/Layout.test.ts
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Layout from '@/components/Layout';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe('<Layout />', () => {
+  beforeEach(() => {
+    render(Layout);
+  });
+
+  it('Should render', () => {
+    const layout = screen.getByTestId('layout');
+    expect(layout).toBeInTheDocument();
+  });
+
+  it('Should render a header', () => {
+    const header = screen.getByRole('banner')
+    expect(header).toBeInTheDocument();
+  });
+
+  it('Should render a menu', () => {
+    const menu = screen.getByRole('list');
+    expect(menu).toBeInTheDocument();
+  });
+});

--- a/tests/components/Layout/subcomponents/Header.test.ts
+++ b/tests/components/Layout/subcomponents/Header.test.ts
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Header } from '@/components/Layout/subcomponents';
+
+describe('<Header />', () => {
+  let menuButtonClickHandler = vi.fn();
+
+  beforeEach(() => {
+    render(Header, {
+      onMenuButtonClick: menuButtonClickHandler
+    });
+  });
+
+  it('Should render', () => {
+    const header = screen.getByRole('banner');
+    expect(header).toBeInTheDocument();
+  });
+
+  it('Should render a title', () => {
+    const title = screen.getByRole('heading', {
+      level: 1,
+      name: 'Music'
+    });
+    expect(title).toBeInTheDocument();
+  });
+
+  it('Should render a menu button', () => {
+    const menuButton = screen.getByRole('button', { name: 'Menu' });
+    expect(menuButton).toBeInTheDocument();
+  });
+
+  describe('When menu button is clicked', () => {
+    it('Should call onMenuButtonClick callback function', async () => {
+      const user = userEvent.setup();
+      const menuButton = screen.getByRole('button', { name: 'Menu' });
+      await user.click(menuButton);
+      expect(menuButtonClickHandler).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/tests/components/Layout/subcomponents/Menu/Menu.test.ts
+++ b/tests/components/Layout/subcomponents/Menu/Menu.test.ts
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Menu } from '@/components/Layout/subcomponents';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe('<Menu />', () => {
+  describe('Regular use', () => {
+    beforeEach(() => {
+      render(Menu);
+    });
+  
+    it('Should render', () => {
+      const menu = screen.getByRole('list');
+      expect(menu).toBeInTheDocument();
+    });
+  
+    it('Should render a Theme dropdown', () => {
+      const dropdown = screen.getByRole('combobox', { name: 'Theme' });
+      expect(dropdown).toBeInTheDocument();
+    });
+
+    it('Should default theme to user\'s system preferred settings', () => {
+      const dropdown = screen.getByRole('combobox', { name: 'Theme' });
+      expect(dropdown).toHaveValue('system');
+    });
+  });
+
+  describe('When setting the theme', () => {
+    beforeEach(() => {
+      render(Menu);
+    });
+
+    it('Should save the theme in localstorage', async () => {
+      const dropdown = screen.getByRole('combobox', { name: 'Theme' });
+      userEvent.selectOptions(dropdown, 'light');
+      const savedTheme = window.localStorage.getItem('theme');
+      waitFor(() => expect(savedTheme).toBe('light'));
+    });
+  });
+
+  describe('When a theme has been set in a previous session', () => {
+    beforeEach(() => {
+      window.localStorage.setItem('theme', 'light');
+      render(Menu);
+    });
+
+    afterEach(() => {
+      window.localStorage.removeItem('theme');
+    });
+
+    it('Should persist theme between sessions', () => {
+      const dropdown = screen.getByRole('combobox', { name: 'Theme' });
+      expect(dropdown).toHaveValue('light');
+    });
+  });
+});

--- a/tests/components/Layout/subcomponents/Menu/utils/getTheme.test.ts
+++ b/tests/components/Layout/subcomponents/Menu/utils/getTheme.test.ts
@@ -1,0 +1,42 @@
+import { getTheme } from '@/components/Layout/subcomponents/Menu/utils';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('getTheme', () => {
+  it('Should default to "system"', () => {
+    const theme = getTheme();
+    expect(theme).toBe('system');
+  });
+
+  it('Should attempt to get a theme from localStorage', () => {
+    const mockedLocalStorageGetItem = vi.spyOn(
+      Object.getPrototypeOf(window.localStorage),
+      'getItem'
+    );
+    getTheme();
+    expect(mockedLocalStorageGetItem).toHaveBeenCalledWith('theme');
+  });
+
+  describe('When dark theme is set in localStorage', () => {
+    it('Should return dark theme', () => {
+      const test = vi.spyOn(
+        Object.getPrototypeOf(window.localStorage),
+        'getItem'
+      );
+      test.mockImplementationOnce(() => 'dark');
+      const theme = getTheme();
+      expect(theme).toBe('dark');
+    });
+  });
+
+  describe('When light theme is set in localStorage', () => {
+    it('Should return light theme', () => {
+      const test = vi.spyOn(
+        Object.getPrototypeOf(window.localStorage),
+        'getItem'
+      );
+      test.mockImplementationOnce(() => 'light');
+      const theme = getTheme();
+      expect(theme).toBe('light');
+    });
+  });
+});

--- a/tests/components/Layout/subcomponents/Menu/utils/setTheme.test.ts
+++ b/tests/components/Layout/subcomponents/Menu/utils/setTheme.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { setTheme } from '@/components/Layout/subcomponents/Menu/utils';
+
+describe('setTheme', () => {
+  describe('When passed light', () => {
+    it('Should set theme on localstorage as "light"', () => {
+      setTheme('light');
+      const savedTheme = window.localStorage.getItem('theme');
+      expect(savedTheme).toBe('light');
+    });
+  });
+
+  describe('When passed dark', () => {
+    it('Should set theme on localstorage as "dark"', () => {
+      setTheme('dark');
+      const savedTheme = window.localStorage.getItem('theme');
+      expect(savedTheme).toBe('dark');
+    });
+  });
+
+  describe('When passed an invalid theme', () => {
+    it('Should throw an error', () => {
+      expect(() => setTheme('invalid')).toThrowError;
+    });
+  });
+});

--- a/tests/components/Piano.test.ts
+++ b/tests/components/Piano.test.ts
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Piano } from '@/components';
+import { notes } from '@/utils';
+
+describe('<Piano />', () => {
+  beforeEach(() => {
+    render(Piano);
+  });
+
+  it('Should render', () => {
+    const piano = screen.getByTestId('piano');
+    expect(piano).toBeInTheDocument();
+  });
+
+  it('Should render all notes as keys', () => {
+    notes.forEach(note => {
+      const key = screen.getByRole('button', { name: note });
+      expect(key).toBeInTheDocument();
+    });
+  });
+
+  it('Should indicate selected keys', () => {
+    ['A', 'B', 'C', 'D', 'E', 'F', 'G'].forEach(note => {
+      const key = screen.getByRole('button', { name: note });
+      expect(key).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  it('Should not indicate non-selected keys', () => {
+    ['C#', 'D#', 'F#', 'G#', 'A#'].forEach(note => {
+      const key = screen.getByRole('button', { name: note });
+      expect(key).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  it('When clicked, should toggle and indicate current key', async () => {
+    const key = screen.getByRole('button', { name: 'C' });
+    expect(key).toHaveAttribute('aria-current', 'false');
+    await userEvent.click(key);
+    expect(key).toHaveAttribute('aria-current', 'location');
+    await userEvent.click(key);
+    expect(key).toHaveAttribute('aria-current', 'false');
+  });
+});

--- a/tests/components/ScaleConfig/ScaleConfig.test.ts
+++ b/tests/components/ScaleConfig/ScaleConfig.test.ts
@@ -1,0 +1,92 @@
+import { ScaleConfig } from '@/components';
+import { getModeNames, getScaleNames } from '@/components/ScaleConfig/utils';
+import { notes } from '@/utils';
+import { render, screen, within } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('<ScaleConfig />', () => {
+  beforeEach(() => {
+    render(ScaleConfig);
+  });
+
+  it('Should render', () => {
+    const scaleConfig = screen.getByRole('form');
+    expect(scaleConfig).toBeInTheDocument();
+  });
+
+  it('Should render a heading displaying the current scale', () => {
+    const heading = screen.getByRole('heading', {
+      level: 2,
+      name: /The C ionian mode of the diatonic scale/
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('Should render a control for the root', () => {
+    const control = screen.getByRole('combobox', { name: /Root/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Should render an option for each note in root control', () => {
+    const control = screen.getByRole('combobox', { name: /Root/ });
+    notes.forEach(note => {
+      const option = within(control).getByRole('option', { name: note });
+      expect(option).toBeInTheDocument();
+    });
+  });
+
+  it('Should render a control for the scale', () => {
+    const control = screen.getByRole('combobox', { name: /Scale/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Should render an option for each scale in scale control', () => {
+    const control = screen.getByRole('combobox', { name: /Scale/ });
+    const scales = getScaleNames();
+    scales.forEach(scale => {
+      const option = within(control).getByRole('option', { name: scale });
+      expect(option).toBeInTheDocument();
+    });
+  });
+
+  it('Should render a control for the mode', () => {
+    const control = screen.getByRole('combobox', { name: /Mode/ });
+    expect(control).toBeInTheDocument();
+  });
+
+  it('Mode control should feature all modes for each scale', async () => {
+    const scaleControl = screen.getByRole('combobox', { name: /Scale/ });
+    const modeControl = screen.getByRole('combobox', { name: /Mode/ });
+    const scales = getScaleNames();
+    for await (const scale of scales) {
+      const scaleOption = within(scaleControl).getByRole('option', { name: scale });
+      await userEvent.selectOptions(scaleControl, scaleOption);
+      const modes = getModeNames(scale);
+      modes.forEach(mode => {
+        const modeOption = within(modeControl).getByRole('option', { name: mode });
+        expect(modeOption).toBeInTheDocument();
+      });
+    }
+  });
+
+  it('Should render the current notes in the given scale and mode', async () => {
+    const rootControl = screen.getByRole('combobox', { name: /Root/ });
+    const scaleControl = screen.getByRole('combobox', { name: /Scale/ });
+    const modeControl = screen.getByRole('combobox', { name: /Mode/ });
+    {
+      const text = screen.getByText(/Featuring the notes: C, D, E, F, G, A, and B./);
+      expect(text).toBeInTheDocument();
+    }
+    {
+      const rootOption = within(rootControl).getByRole('option', { name: /^A$/i });
+      await userEvent.selectOptions(rootControl, rootOption);
+      const scaleOption = within(scaleControl).getByRole('option', { name: /Pentatonic/i });
+      await userEvent.selectOptions(scaleControl, scaleOption);
+      const modeOption = within(modeControl).getByRole('option', { name: /Minor/i });
+      await userEvent.selectOptions(modeControl, modeOption);
+      const text = screen.getByText(/Featuring the notes: A, C, D, E, and G./);
+      expect(text).toBeInTheDocument();
+    }
+  });
+});

--- a/tests/components/ScaleConfig/utils/getModeNames.test.ts
+++ b/tests/components/ScaleConfig/utils/getModeNames.test.ts
@@ -1,0 +1,39 @@
+import { getModeNames } from '@/components/ScaleConfig/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('getModeNames()', () => {
+  describe('When called with the chromatic scale', () => {
+    const modes = getModeNames('chromatic');
+
+    it('Should return a list of chromatic modes', () => {
+      expect(modes).toEqual(['chromatic']);
+    });
+  });
+
+  describe('When called with the diatonic scale', () => {
+    const modes = getModeNames('diatonic');
+
+    it('Should return a list of diatonic modes', () => {
+      expect(modes).toEqual([
+        'ionian',
+        'dorian',
+        'phrygian',
+        'lydian',
+        'mixolydian',
+        'aeolian',
+        'locrian'
+      ]);
+    });
+  });
+  
+  describe('When called with the pentatonic scale', () => {
+    const modes = getModeNames('pentatonic');
+
+    it('Should return a list of pentatonic modes', () => {
+      expect(modes).toEqual([
+        'major',
+        'minor'
+      ]);
+    });
+  });
+});

--- a/tests/components/ScaleConfig/utils/getScaleNames.test.ts
+++ b/tests/components/ScaleConfig/utils/getScaleNames.test.ts
@@ -1,0 +1,14 @@
+import { getScaleNames } from '@/components/ScaleConfig/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('getScaleNames()', () => {
+  const scaleNames = getScaleNames();
+
+  it('Should return a list of scale names', () => {
+    expect(scaleNames).toEqual([
+      'chromatic',
+      'diatonic',
+      'pentatonic'
+    ]);
+  });
+});

--- a/tests/components/ScaleConfig/utils/getScalePattern.test.ts
+++ b/tests/components/ScaleConfig/utils/getScalePattern.test.ts
@@ -1,0 +1,20 @@
+import { getScalePattern, scalePatterns } from '@/components/ScaleConfig/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('getScalePattern()', () => {
+  describe('When passed a valid scale and mode', () => {
+    it('Should return the correct scale pattern', () => {
+      const chromaticPattern = getScalePattern('chromatic', 'chromatic');
+      const chromaticExpectedPattern = scalePatterns.chromatic.chromatic;
+      expect(chromaticPattern).toEqual(chromaticExpectedPattern);
+
+      const diatonicPattern = getScalePattern('diatonic', 'phrygian');
+      const diatonicExpectedPattern = scalePatterns.diatonic.phrygian;
+      expect(diatonicPattern).toEqual(diatonicExpectedPattern);
+
+      const pentatonicPattern = getScalePattern('pentatonic', 'minor');
+      const pentatonicExpectedPattern = scalePatterns.pentatonic.minor;
+      expect(pentatonicPattern).toEqual(pentatonicExpectedPattern);
+    });
+  });
+});

--- a/tests/components/Tooltip.test.ts
+++ b/tests/components/Tooltip.test.ts
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import Tooltip from '@/components/Tooltip';
+
+describe('<Tooltip />', () => {
+  describe('When given a description', () => {
+    beforeEach(() => {
+      render(Tooltip, {
+        details: 'Test'
+      });
+    });
+  
+    it('Should render', () => {
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toBeInTheDocument();
+    });
+  
+    it('Should render a description', () => {
+      const description = screen.getByText(/Test/);
+      expect(description).toBeInTheDocument();
+    });
+  });
+
+  describe('When not given a description', () => {
+    beforeEach(() => {
+      render(Tooltip);
+    });
+
+    it('Should not render', () => {
+      const tooltip = screen.queryByRole('tooltip');
+      expect(tooltip).toBeNull();
+    });
+  });
+});

--- a/tests/vitest-setup.ts
+++ b/tests/vitest-setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/svelte/vitest';
+import '@testing-library/jest-dom/vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,12 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte", "tests"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.svelte",
+    "tests/vitest-setup.ts",
+    "tests/**/*.test.ts"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
+import path from 'path';
 
 export default defineConfig(({ mode }) => ({
   plugins: [svelte()],
   resolve: {
-    conditions: mode === 'test' ? ['browser'] : []
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    },
+    conditions: mode === 'test' ? ['browser'] : [],
   },
   test: {
     environment: 'jsdom',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  plugins: [svelte()],
+  resolve: {
+    conditions: mode === 'test' ? ['browser'] : []
+  },
   test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/vitest-setup.ts'],
     coverage: {
       reportsDirectory: './tests/coverage'
     }
   }
-});
+}));


### PR DESCRIPTION
# #81 Add component unit tests

Adds unit tests to existing components

## Description

This PR marks the start of shifting towards testing the application

This covers most logic within the components directory

There's still more testing to be added outside the scope of this ticket

## Notes

- I added in some `data-test-id` attributes for ease of testing, these should be replaced with better accessibility and I have created tickets to follow this up

## Changes

- Set up svelte component testing infrastructure
- Added @testing-library/user-event dependency
- Added module aliasing for tests
- Excluded coverage reports from typechecking
- Added Dropdown component
- Replaced theme native select with Dropdown component
- Abstracted Layout Header to a subcomponent and added unit tests
- Abstracted getTheme and added tests
- Abstracted setTheme and added tests
- Abstracted Menu component and added tests
- Simplified Layout component structure
- Added Layout component tests
- Added unit tests for Tooltip
- Added unit tests for Fret component
- Added unit tests for String subcomponent
- Added unit tests for Guitar Config
- Added unit tests for Guitar component
- Added unit tests for CircleOfFifths
- Added unit tests for Piano
- Added unit tests for getScaleNames
- Added unit tests for getModeNames
- Added unit tests for getScalePattern
- Added unit tests for ScaleConfig
- Set Fret styles to use aria accessibility attributes
- Simplified aria accessibility attribute logic