### PR TITLE
#75 Added local save for instruments setup

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,39 +1,5 @@
 <script lang="ts">
-  import { CircleOfFifths, Guitar, Layout, Piano, ScaleConfig } from '@/components';
-  import { getUID } from '@/utils';
-
-  type InstrumentTypes = 'guitar' | 'piano';
-
-  type Instrument = {
-    id: number;
-    type: InstrumentTypes;
-  };
-
-  let instruments: Instrument[] = [
-    {
-      id: getUID(),
-      type: 'guitar'
-    },
-    {
-      id: getUID(),
-      type: 'piano'
-    }
-  ];
-
-  function addInstrument(type: InstrumentTypes) {
-    instruments = [
-      ...instruments,
-      {
-        id: getUID(),
-        type
-      }
-    ];
-  }
-
-  function removeInstrument(index: number) {
-    instruments.splice(index, 1);
-    instruments = instruments;
-  }
+  import { CircleOfFifths, Instruments, Layout, ScaleConfig } from '@/components';
 </script>
 
 <Layout>
@@ -51,24 +17,7 @@
     <h2>
       Instruments
     </h2>
-    <div>
-      {#each instruments as { id, type }, i (id)}
-        {#if type === 'guitar'}
-          <Guitar />
-        {:else if type === 'piano'}
-          <Piano />
-        {/if}
-        <button on:click={() => removeInstrument(i)}>
-          Remove
-        </button>
-      {/each}
-    </div>
-    <button on:click={() => addInstrument('guitar')}>
-      Add Guitar
-    </button>
-    <button on:click={() => addInstrument('piano')}>
-      Add Piano
-    </button>
+    <Instruments />
   </main>
 </Layout>
 

--- a/src/components/Instruments/Instruments.scss
+++ b/src/components/Instruments/Instruments.scss
@@ -1,0 +1,13 @@
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.heading {
+  color: var(--text-dark-high-emphasis);
+
+  &__id {
+    color: var(--text-dark-low-emphasis);
+  }
+}

--- a/src/components/Instruments/Instruments.svelte
+++ b/src/components/Instruments/Instruments.svelte
@@ -3,21 +3,37 @@
   import { instruments } from '@/stores';
 </script>
 
-<div>
+<ul class="list">
   {#each $instruments as { id, type } (id)}
-    {#if type === 'guitar'}
-      <Guitar />
-    {:else if type === 'piano'}
-      <Piano />
-    {/if}
-    <button on:click={() => instruments.remove(id)}>
-      Remove
-    </button>
+    <li aria-labelledby="instrument-label-{id}">
+      <h3
+        class="heading"
+        id="instrument-label-{id}"
+      >
+        {type}
+        {' '}
+        <span class="heading__id">
+          (id: {id})
+        </span>
+      </h3>
+      {#if type === 'guitar'}
+        <Guitar />
+      {:else if type === 'piano'}
+        <Piano />
+      {/if}
+      <button on:click={() => instruments.remove(id)}>
+        Remove
+      </button>
+    </li>
   {/each}
-</div>
+</ul>
 <button on:click={() => instruments.add('guitar')}>
   Add Guitar
 </button>
 <button on:click={() => instruments.add('piano')}>
   Add Piano
 </button>
+
+<style lang="scss">
+  @import './Instruments.scss';
+</style>

--- a/src/components/Instruments/Instruments.svelte
+++ b/src/components/Instruments/Instruments.svelte
@@ -1,56 +1,23 @@
 <script lang="ts">
   import { Guitar, Piano } from '@/components';
-  import { getUID } from '@/utils';
-
-  type InstrumentTypes = 'guitar' | 'piano';
-
-  type Instrument = {
-    id: number;
-    type: InstrumentTypes;
-  };
-
-  let instruments: Instrument[] = [
-    {
-      id: getUID(),
-      type: 'guitar'
-    },
-    {
-      id: getUID(),
-      type: 'piano'
-    }
-  ];
-
-  function addInstrument(type: InstrumentTypes) {
-    instruments = [
-      ...instruments,
-      {
-        id: getUID(),
-        type
-      }
-    ];
-  }
-
-  function removeInstrument(index: number) {
-    instruments.splice(index, 1);
-    instruments = instruments;
-  }
+  import { instruments } from '@/stores';
 </script>
 
 <div>
-  {#each instruments as { id, type }, i (id)}
+  {#each $instruments as { id, type } (id)}
     {#if type === 'guitar'}
       <Guitar />
     {:else if type === 'piano'}
       <Piano />
     {/if}
-    <button on:click={() => removeInstrument(i)}>
+    <button on:click={() => instruments.remove(id)}>
       Remove
     </button>
   {/each}
 </div>
-<button on:click={() => addInstrument('guitar')}>
+<button on:click={() => instruments.add('guitar')}>
   Add Guitar
 </button>
-<button on:click={() => addInstrument('piano')}>
+<button on:click={() => instruments.add('piano')}>
   Add Piano
 </button>

--- a/src/components/Instruments/Instruments.svelte
+++ b/src/components/Instruments/Instruments.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { Guitar, Piano } from '@/components';
+  import { getUID } from '@/utils';
+
+  type InstrumentTypes = 'guitar' | 'piano';
+
+  type Instrument = {
+    id: number;
+    type: InstrumentTypes;
+  };
+
+  let instruments: Instrument[] = [
+    {
+      id: getUID(),
+      type: 'guitar'
+    },
+    {
+      id: getUID(),
+      type: 'piano'
+    }
+  ];
+
+  function addInstrument(type: InstrumentTypes) {
+    instruments = [
+      ...instruments,
+      {
+        id: getUID(),
+        type
+      }
+    ];
+  }
+
+  function removeInstrument(index: number) {
+    instruments.splice(index, 1);
+    instruments = instruments;
+  }
+</script>
+
+<div>
+  {#each instruments as { id, type }, i (id)}
+    {#if type === 'guitar'}
+      <Guitar />
+    {:else if type === 'piano'}
+      <Piano />
+    {/if}
+    <button on:click={() => removeInstrument(i)}>
+      Remove
+    </button>
+  {/each}
+</div>
+<button on:click={() => addInstrument('guitar')}>
+  Add Guitar
+</button>
+<button on:click={() => addInstrument('piano')}>
+  Add Piano
+</button>

--- a/src/components/Instruments/Instruments.svelte
+++ b/src/components/Instruments/Instruments.svelte
@@ -33,6 +33,9 @@
 <button on:click={() => instruments.add('piano')}>
   Add Piano
 </button>
+<button on:click={() => instruments.reset()}>
+  Reset to Default
+</button>
 
 <style lang="scss">
   @import './Instruments.scss';

--- a/src/components/Instruments/index.ts
+++ b/src/components/Instruments/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Instruments.svelte';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as CircleOfFifths } from './CircleOfFifths';
 export { default as Dropdown } from './Dropdown';
 export { default as Guitar } from './Guitar';
+export { default as Instruments } from './Instruments';
 export { default as Layout } from './Layout';
 export { default as Piano } from './Piano';
 export { default as ScaleConfig } from './ScaleConfig';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,5 @@
 export { default as highlightedNotes } from './highlightedNotes';
+export { default as instruments } from './instruments';
 export { default as mode } from './mode';
 export { default as root } from './root';
 export { default as selectedNote } from './selectedNote';

--- a/src/stores/instruments.ts
+++ b/src/stores/instruments.ts
@@ -1,0 +1,42 @@
+import { writable } from 'svelte/store';
+import { getUID } from '@/utils';
+
+type Instrument = {
+  id: number;
+  type: 'guitar' | 'piano';
+};
+
+const { subscribe, update } = writable<Instrument[]>([
+  {
+    id: getUID(),
+    type: 'guitar'
+  },
+  {
+    id: getUID(),
+    type: 'piano'
+  }
+]);
+
+export default {
+  subscribe,
+  add: (type: Instrument['type']) => {
+    update(instruments => (
+      [
+        ...instruments,
+        {
+          id: getUID(),
+          type
+        }
+      ]
+    ));
+  },
+  remove: (id: number) => {
+    update(instruments => {
+      const index = instruments.findIndex(instrument => instrument.id === id);
+      return [
+        ...instruments.slice(0, index),
+        ...instruments.slice(index + 1)
+      ];
+    });
+  }
+};

--- a/src/stores/instruments.ts
+++ b/src/stores/instruments.ts
@@ -17,7 +17,7 @@ const defaultInstruments: Instrument[] = [
   }
 ];
 
-const { set, subscribe, update } = writable<Instrument[]>([...defaultInstruments]);
+const { set, subscribe, update } = writable<Instrument[]>(defaultInstruments);
 
 const localInstruments = window.localStorage.getItem('instruments');
 
@@ -63,6 +63,6 @@ export default {
     });
   },
   reset: () => {
-    set([...defaultInstruments]);
+    set(defaultInstruments);
   }
 };

--- a/src/stores/instruments.ts
+++ b/src/stores/instruments.ts
@@ -6,7 +6,7 @@ type Instrument = {
   type: 'guitar' | 'piano';
 };
 
-const { subscribe, update } = writable<Instrument[]>([
+const defaultInstruments: Instrument[] = [
   {
     id: getUID(),
     type: 'guitar'
@@ -15,28 +15,54 @@ const { subscribe, update } = writable<Instrument[]>([
     id: getUID(),
     type: 'piano'
   }
-]);
+];
+
+const { set, subscribe, update } = writable<Instrument[]>([...defaultInstruments]);
+
+const localInstruments = window.localStorage.getItem('instruments');
+
+function updateLocalInstruments(instruments: Instrument[]) {
+  window.localStorage.setItem(
+    'instruments',
+    JSON.stringify(instruments)
+  );
+}
+
+if (localInstruments) {
+  const instruments = JSON.parse(localInstruments);
+  if (instruments.length) {
+    set(instruments);
+  }
+}
 
 export default {
   subscribe,
   add: (type: Instrument['type']) => {
-    update(instruments => (
-      [
+    update(instruments => {
+      const updatedInstruments = [
         ...instruments,
         {
           id: getUID(),
           type
         }
-      ]
-    ));
+      ];
+      updateLocalInstruments(updatedInstruments);
+      return updatedInstruments;
+    });
+
   },
   remove: (id: number) => {
     update(instruments => {
       const index = instruments.findIndex(instrument => instrument.id === id);
-      return [
+      const updatedInstruments = [
         ...instruments.slice(0, index),
         ...instruments.slice(index + 1)
       ];
+      updateLocalInstruments(updatedInstruments);
+      return updatedInstruments;
     });
+  },
+  reset: () => {
+    set([...defaultInstruments]);
   }
 };

--- a/tests/components/Instruments.test.ts
+++ b/tests/components/Instruments.test.ts
@@ -1,0 +1,50 @@
+import { Instruments } from '@/components';
+import { render, screen, within } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('<Instruments />', () => {
+  const instruments = [
+    {
+      type: 'guitar',
+      id: 0
+    },
+    {
+      type: 'piano',
+      id: 1
+    }
+  ];
+
+  beforeEach(() => {
+    render(Instruments);
+  });
+
+  it('Should render a list of instruments', () => {
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+  });
+
+  it('Should render each instrument with a heading and remove button', () => {
+    instruments.forEach(({ type, id }) => {
+      const instrument = screen.getByRole('listitem', { name: `${type} (id: ${id})` });
+      expect(instrument).toBeInTheDocument();
+    });
+  });
+
+  it('Should render a remove instrument button with each instrument', () => {
+    instruments.forEach(({ type, id }) => {
+      const instrument = screen.getByRole('listitem', { name: `${type} (id: ${id})` });
+      const button = within(instrument).getByRole('button', { name: /Remove/ });
+      expect(button).toBeInTheDocument();
+    });
+  });
+
+  it('Should render an add guitar button', () => {
+    const button = screen.getByRole('button', { name: /Add Guitar/ });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('Should render an add piano button', () => {
+    const button = screen.getByRole('button', { name: /Add Piano/ });
+    expect(button).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# #75 Added local save for instruments setup

Sets the application to remember the users last instrument set up (ie. number of guitars, pianos)

## Notes

- This does **not** cover individual instrument config, this will be handled in a future ticket

## Changes

- Abstracted Instruments to its own component
- Abstracted instruments to store
- Set instruments to be accessible list with basic headings and styles
- Added Instruments unit tests
- Updated instrument store to use localStorage
- Added reset to default button for instruments