### PR TITLE
#88 Convert guitar to navigable grid

### DIFF
--- a/src/components/Guitar/Guitar.scss
+++ b/src/components/Guitar/Guitar.scss
@@ -1,3 +1,8 @@
+.fretboard {
+  width: 100%;
+  border-spacing: 0;
+}
+
 .fret-markers {
   display: flex;
   box-sizing: border-box;

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -17,7 +17,7 @@
     fret: 0
   };
 
-  function moveTo({ string, fret }: { string: number, fret: number }) {
+  function focusFret({ string, fret }: { string: number, fret: number }) {
     const target = document.querySelector<HTMLTableCellElement>(
       `[data-row="${string}"][data-column="${fret}"]`
     );
@@ -58,7 +58,7 @@
         switch (event.key) {
           case 'Enter': {
             event.preventDefault();
-            moveTo({
+            focusFret({
               string: current.string,
               fret: current.fret
             });
@@ -71,7 +71,7 @@
           }
           case 'ArrowLeft': {
             event.preventDefault();
-            moveTo({
+            focusFret({
               string: current.string,
               fret: current.fret - 1
             });
@@ -79,7 +79,7 @@
           }
           case 'ArrowRight': {
             event.preventDefault();
-            moveTo({
+            focusFret({
               string: current.string,
               fret: current.fret + 1
             });
@@ -87,7 +87,7 @@
           }
           case 'ArrowUp': {
             event.preventDefault();
-            moveTo({
+            focusFret({
               string: current.string - 1,
               fret: current.fret
             });
@@ -95,7 +95,7 @@
           }
           case 'ArrowDown': {
             event.preventDefault();
-            moveTo({
+            focusFret({
               string: current.string + 1,
               fret: current.fret
             });
@@ -109,6 +109,7 @@
           {tuning}
           {numberOfFrets}
           {stringNumber}
+          {focusFret}
         />
       {/each}
     </table>

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -8,7 +8,26 @@
   let fretMarkers = ['3', '5', '7', '9', '12', '15', '17', '19', '21'];
   let displayConfig = false;
 
+  let fretboardElement: HTMLTableElement;
+
   $: frets = getRange(0, numberOfFrets, { format: 'string' });
+
+  const current = {
+    string: 0,
+    fret: 0
+  };
+
+  function moveTo({ string, fret }: { string: number, fret: number }) {
+    const target = document.querySelector<HTMLTableCellElement>(
+      `[data-row="${string}"][data-column="${fret}"]`
+    );
+    if (!target) {
+      return;
+    }
+    current.string = string;
+    current.fret = fret;
+    target.focus();
+  }
 </script>
 
 <!-- TODO: Replace test id with something accessible -->
@@ -30,11 +49,66 @@
         </div>
       {/each}
     </div>
-    <table class="fretboard">
-      {#each stringTunings.toReversed() as tuning}
+    <table
+      class="fretboard"
+      role="grid"
+      tabindex="0"
+      bind:this={fretboardElement}
+      on:keydown={(event) => {
+        switch (event.key) {
+          case 'Enter': {
+            event.preventDefault();
+            moveTo({
+              string: current.string,
+              fret: current.fret
+            });
+            break;
+          }
+          case 'Escape': {
+            event.preventDefault();
+            fretboardElement.focus();
+            break;
+          }
+          case 'ArrowLeft': {
+            event.preventDefault();
+            moveTo({
+              string: current.string,
+              fret: current.fret - 1
+            });
+            break;
+          }
+          case 'ArrowRight': {
+            event.preventDefault();
+            moveTo({
+              string: current.string,
+              fret: current.fret + 1
+            });
+            break;
+          }
+          case 'ArrowUp': {
+            event.preventDefault();
+            moveTo({
+              string: current.string - 1,
+              fret: current.fret
+            });
+            break;
+          }
+          case 'ArrowDown': {
+            event.preventDefault();
+            moveTo({
+              string: current.string + 1,
+              fret: current.fret
+            });
+            break;
+          }
+        }
+      }}
+    >
+      {#each stringTunings.toReversed() as tuning, stringNumber}
         <String
           {tuning}
           {numberOfFrets}
+          {stringNumber}
         />
       {/each}
     </table>

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -1,33 +1,16 @@
 <script lang="ts">
   import { getRange } from '@/utils';
   import { Config, String } from './subcomponents';
+  import { handleKeyboardEvent } from './utils';
 
+  let fretboardElement: HTMLTableElement;
   let numberOfFrets = 22;
   let numberOfStrings = 6;
   let stringTunings = ['E', 'A', 'D', 'G', 'B', 'E'];
   let fretMarkers = ['3', '5', '7', '9', '12', '15', '17', '19', '21'];
   let displayConfig = false;
 
-  let fretboardElement: HTMLTableElement;
-
   $: frets = getRange(0, numberOfFrets, { format: 'string' });
-
-  const current = {
-    string: 0,
-    fret: 0
-  };
-
-  function focusFret({ string, fret }: { string: number, fret: number }) {
-    const target = document.querySelector<HTMLTableCellElement>(
-      `[data-row="${string}"][data-column="${fret}"]`
-    );
-    if (!target) {
-      return;
-    }
-    current.string = string;
-    current.fret = fret;
-    target.focus();
-  }
 </script>
 
 <!-- TODO: Replace test id with something accessible -->
@@ -54,62 +37,13 @@
       role="grid"
       tabindex="0"
       bind:this={fretboardElement}
-      on:keydown={(event) => {
-        switch (event.key) {
-          case 'Enter': {
-            event.preventDefault();
-            focusFret({
-              string: current.string,
-              fret: current.fret
-            });
-            break;
-          }
-          case 'Escape': {
-            event.preventDefault();
-            fretboardElement.focus();
-            break;
-          }
-          case 'ArrowLeft': {
-            event.preventDefault();
-            focusFret({
-              string: current.string,
-              fret: current.fret - 1
-            });
-            break;
-          }
-          case 'ArrowRight': {
-            event.preventDefault();
-            focusFret({
-              string: current.string,
-              fret: current.fret + 1
-            });
-            break;
-          }
-          case 'ArrowUp': {
-            event.preventDefault();
-            focusFret({
-              string: current.string - 1,
-              fret: current.fret
-            });
-            break;
-          }
-          case 'ArrowDown': {
-            event.preventDefault();
-            focusFret({
-              string: current.string + 1,
-              fret: current.fret
-            });
-            break;
-          }
-        }
-      }}
+      on:keydown={(event) => handleKeyboardEvent(event, fretboardElement)}
     >
       {#each stringTunings.toReversed() as tuning, stringNumber}
         <String
           {tuning}
           {numberOfFrets}
           {stringNumber}
-          {focusFret}
         />
       {/each}
     </table>

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -30,12 +30,14 @@
         </div>
       {/each}
     </div>
-    {#each stringTunings.toReversed() as tuning}
-      <String
-        {tuning}
-        {numberOfFrets}
-      />
-    {/each}
+    <table class="fretboard">
+      {#each stringTunings.toReversed() as tuning}
+        <String
+          {tuning}
+          {numberOfFrets}
+        />
+      {/each}
+    </table>
     <div class="fret-markers">
       {#each frets as fret}
         <div class="fret-markers__item">

--- a/src/components/Guitar/Guitar.svelte
+++ b/src/components/Guitar/Guitar.svelte
@@ -33,6 +33,7 @@
       {/each}
     </div>
     <table
+      aria-label="Guitar Fretboard"
       class="fretboard"
       role="grid"
       tabindex="0"

--- a/src/components/Guitar/stores/focussedFret.ts
+++ b/src/components/Guitar/stores/focussedFret.ts
@@ -1,0 +1,6 @@
+import { writable } from 'svelte/store';
+
+export default writable({
+  string: 0,
+  fret: 0
+});

--- a/src/components/Guitar/stores/index.ts
+++ b/src/components/Guitar/stores/index.ts
@@ -1,0 +1,1 @@
+export { default as focussedFret } from './focussedFret';

--- a/src/components/Guitar/subcomponents/Fret/Fret.scss
+++ b/src/components/Guitar/subcomponents/Fret/Fret.scss
@@ -14,6 +14,10 @@
     background-color: hsl(from var(--background-color) h s 50);
   }
 
+  &:focus {
+    background-color: hsl(from var(--background-color) h s 70);
+  }
+
   &:first-child {
     --background-color: black;
     color: var(--text-light-low-emphasis-locked);
@@ -27,6 +31,10 @@
       color: var(--text-dark-low-emphasis-locked);
 
       &:hover {
+        background-color: hsl(from var(--background-color) h s 70);
+      }
+
+      &:focus {
         background-color: hsl(from var(--background-color) h s 80);
       }
     }

--- a/src/components/Guitar/subcomponents/Fret/Fret.scss
+++ b/src/components/Guitar/subcomponents/Fret/Fret.scss
@@ -14,10 +14,6 @@
     background-color: hsl(from var(--background-color) h s 50);
   }
 
-  &:focus {
-    background-color: hsl(from var(--background-color) h s 70);
-  }
-
   &:first-child {
     --background-color: black;
     color: var(--text-light-low-emphasis-locked);
@@ -32,10 +28,6 @@
 
       &:hover {
         background-color: hsl(from var(--background-color) h s 70);
-      }
-
-      &:focus {
-        background-color: hsl(from var(--background-color) h s 80);
       }
     }
   }
@@ -55,11 +47,16 @@
   }
 
   &[aria-current="location"] > &__indicator {
-    border: var(--text-light-low-emphasis-locked) 0.25rem solid;
+    border: var(--text-light-low-emphasis-locked) 0.125rem solid;
     background-color: var(--text-light-disabled-locked);
+  }
+
+  &[aria-current="location"]:focus > &__indicator {
+    border-width: 0.25rem;
+    border-color: rgb(238, 212, 19);
     color: var(--text-dark-contrast-locked);
     font-weight: 700;
-
+    
     :global([data-theme="dark"]) & {
       color: var(--text-dark-contrast);
     }

--- a/src/components/Guitar/subcomponents/Fret/Fret.scss
+++ b/src/components/Guitar/subcomponents/Fret/Fret.scss
@@ -33,6 +33,8 @@
   }
 
   &__indicator {
+    position: relative;
+    z-index: 1;
     display: grid;
     place-content: center;
     width: 1.5rem;
@@ -46,19 +48,24 @@
     font-weight: 700;
   }
 
-  &[aria-current="location"] > &__indicator {
-    border: var(--text-light-low-emphasis-locked) 0.125rem solid;
-    background-color: var(--text-light-disabled-locked);
-  }
+  &[aria-current="location"] {
+    position: relative;
 
-  &[aria-current="location"]:focus > &__indicator {
-    border-width: 0.25rem;
-    border-color: rgb(238, 212, 19);
-    color: var(--text-dark-contrast-locked);
-    font-weight: 700;
-    
-    :global([data-theme="dark"]) & {
-      color: var(--text-dark-contrast);
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: rgba(255, 255, 255, 0.3);
+    }
+
+    &:focus {
+      &::after {
+        outline: solid rgb(238, 212, 19) 0.25rem;
+        outline-offset: -0.25rem;
+      }
     }
   }
 }

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -28,7 +28,7 @@
   role="gridcell"
   tabindex="-1"
   title={getHighlightedNote(note)?.name}
-  on:click={() => selectedNote.select(note)}
+  on:focus={() => selectedNote.select(note)}
   use:tooltip={{ text: getIntervalName(note) }}
   aria-current={isSelected(note) && 'location'}
   aria-selected={isHighlighted(note) ? 'true' : 'false'}

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -21,9 +21,7 @@
   );
 </script>
 
-<!-- TODO: aria-selected should be set to <td /> once Guitar, String, and Fret are an accessible grid -->
-<!-- svelte-ignore a11y-role-supports-aria-props -->
-<button
+<td
   class="fret"
   title={getHighlightedNote(note)?.name}
   on:click={() => selectedNote.select(note)}
@@ -37,7 +35,7 @@
   >
     {note}
   </div>
-</button>
+</td>
 
 <style lang="scss">
   @import './Fret.scss';

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -28,6 +28,7 @@
   role="gridcell"
   tabindex="-1"
   title={getHighlightedNote(note)?.name}
+  on:click
   on:focusin={() => selectedNote.select(note)}
   on:focusout={() => selectedNote.reset()}
   use:tooltip={{ text: getIntervalName(note) }}

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -3,6 +3,8 @@
   import { highlightedNotes, selectedNote } from '@/stores';
 
   export let note = 'E';
+  export let fretNumber: number;
+  export let stringNumber: number;
 
   $: isSelected = (note: string) => (
     $selectedNote?.value === note
@@ -23,11 +25,15 @@
 
 <td
   class="fret"
+  role="gridcell"
+  tabindex="-1"
   title={getHighlightedNote(note)?.name}
   on:click={() => selectedNote.select(note)}
   use:tooltip={{ text: getIntervalName(note) }}
   aria-current={isSelected(note) && 'location'}
   aria-selected={isHighlighted(note) ? 'true' : 'false'}
+  data-row={stringNumber}
+  data-column={fretNumber}
 >
   <div
     class="fret__indicator"

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -28,7 +28,8 @@
   role="gridcell"
   tabindex="-1"
   title={getHighlightedNote(note)?.name}
-  on:focus={() => selectedNote.select(note)}
+  on:focusin={() => selectedNote.select(note)}
+  on:focusout={() => selectedNote.reset()}
   use:tooltip={{ text: getIntervalName(note) }}
   aria-current={isSelected(note) && 'location'}
   aria-selected={isHighlighted(note) ? 'true' : 'false'}

--- a/src/components/Guitar/subcomponents/Fret/Fret.svelte
+++ b/src/components/Guitar/subcomponents/Fret/Fret.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tooltip } from '@/actions';
   import { highlightedNotes, selectedNote } from '@/stores';
+  import { focusFret } from '../../utils';
 
   export let note = 'E';
   export let fretNumber: number;
@@ -28,7 +29,7 @@
   role="gridcell"
   tabindex="-1"
   title={getHighlightedNote(note)?.name}
-  on:click
+  on:click={() => focusFret({ string: stringNumber, fret: fretNumber })}
   on:focusin={() => selectedNote.select(note)}
   on:focusout={() => selectedNote.reset()}
   use:tooltip={{ text: getIntervalName(note) }}

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -4,13 +4,21 @@
 
   export let tuning: string = 'E';
   export let numberOfFrets: number = 22;
+  export let stringNumber: number;
 
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
 
-<tr class="string" data-testId="guitar-string">
-  {#each notes as note}
-    <Fret {note} />
+<tr
+  class="string"
+  data-testId="guitar-string"
+>
+  {#each notes as note, fretNumber}
+    <Fret
+      {note}
+      {stringNumber}
+      {fretNumber}
+    />
   {/each}
 </tr>
 

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -8,12 +8,11 @@
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
 
-<!-- TODO: Replace testId with better role -->
-<div class="string" data-testId="guitar-string">
+<tr class="string" data-testId="guitar-string">
   {#each notes as note}
     <Fret {note} />
   {/each}
-</div>
+</tr>
 
 <style lang="scss">
   @import './String.scss';

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -9,10 +9,7 @@
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
 
-<tr
-  class="string"
-  data-testId="guitar-string"
->
+<tr class="string">
   {#each notes as note, fretNumber}
     <Fret
       {note}

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -5,6 +5,7 @@
   export let tuning: string = 'E';
   export let numberOfFrets: number = 22;
   export let stringNumber: number;
+  export let focusFret: ({ string, fret }: { string: number, fret: number }) => void;
 
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
@@ -18,6 +19,7 @@
       {note}
       {stringNumber}
       {fretNumber}
+      on:click={() => focusFret({ string: stringNumber, fret: fretNumber })}
     />
   {/each}
 </tr>

--- a/src/components/Guitar/subcomponents/String/String.svelte
+++ b/src/components/Guitar/subcomponents/String/String.svelte
@@ -5,7 +5,6 @@
   export let tuning: string = 'E';
   export let numberOfFrets: number = 22;
   export let stringNumber: number;
-  export let focusFret: ({ string, fret }: { string: number, fret: number }) => void;
 
   $: notes = getConsecutiveNotes(tuning, numberOfFrets + 1);
 </script>
@@ -19,7 +18,6 @@
       {note}
       {stringNumber}
       {fretNumber}
-      on:click={() => focusFret({ string: stringNumber, fret: fretNumber })}
     />
   {/each}
 </tr>

--- a/src/components/Guitar/utils/focusFret.ts
+++ b/src/components/Guitar/utils/focusFret.ts
@@ -1,0 +1,15 @@
+import { focussedFret } from '../stores';
+
+export default function focusFret({ string, fret }: { string: number, fret: number }) {
+  const target = document.querySelector<HTMLTableCellElement>(
+    `[data-row="${string}"][data-column="${fret}"]`
+  );
+  if (!target) {
+    return;
+  }
+  focussedFret.set({
+    string,
+    fret
+  });
+  target.focus();
+}

--- a/src/components/Guitar/utils/handleKeyboardEvent.ts
+++ b/src/components/Guitar/utils/handleKeyboardEvent.ts
@@ -1,0 +1,55 @@
+import focusFret from './focusFret';
+import { focussedFret } from '../stores';
+import { get } from 'svelte/store';
+
+export default function handleKeyboardEvent(event: KeyboardEvent, element: HTMLElement) {
+  const { string, fret } = get(focussedFret);
+
+  switch (event.key) {
+    case 'Enter': {
+      event.preventDefault();
+      focusFret({
+        string,
+        fret
+      });
+      break;
+    }
+    case 'Escape': {
+      event.preventDefault();
+      element.focus();
+      break;
+    }
+    case 'ArrowLeft': {
+      event.preventDefault();
+      focusFret({
+        string,
+        fret: fret - 1
+      });
+      break;
+    }
+    case 'ArrowRight': {
+      event.preventDefault();
+      focusFret({
+        string,
+        fret: fret + 1
+      });
+      break;
+    }
+    case 'ArrowUp': {
+      event.preventDefault();
+      focusFret({
+        string: string - 1,
+        fret
+      });
+      break;
+    }
+    case 'ArrowDown': {
+      event.preventDefault();
+      focusFret({
+        string: string + 1,
+        fret
+      });
+      break;
+    }
+  }
+}

--- a/src/components/Guitar/utils/index.ts
+++ b/src/components/Guitar/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as focusFret } from './focusFret';
+export { default as handleKeyboardEvent } from './handleKeyboardEvent';

--- a/src/components/Layout/subcomponents/Menu/Menu.scss
+++ b/src/components/Layout/subcomponents/Menu/Menu.scss
@@ -1,5 +1,6 @@
 .container {
   all: unset;
+  z-index: 10;
   position: absolute;
   left: 0;
   top: 3rem;

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -3,6 +3,7 @@
   --tail-height: 0.5rem;
 
   position: absolute;
+  z-index: 1;
   padding: 1rem;
   background-color: var(--background-colour);
   color: white;

--- a/tests/components/Guitar/Guitar.test.ts
+++ b/tests/components/Guitar/Guitar.test.ts
@@ -22,7 +22,7 @@ describe('<Guitar />', () => {
   });
   
   it('Should render strings', () => {
-    const strings = screen.getAllByTestId('guitar-string');
+    const strings = screen.getAllByRole('row');
     expect(strings.length).toBe(6);
     strings.forEach(string => {
       expect(string).toBeInTheDocument();

--- a/tests/components/Guitar/subcomponents/Fret.test.ts
+++ b/tests/components/Guitar/subcomponents/Fret.test.ts
@@ -15,7 +15,11 @@ vi.mock('@/stores/highlightedNotes', async () => {
 describe('<Fret />', () => {
   describe('Default behaviour', () => {
     beforeEach(() => {
-      render(Fret, { note: 'C' });
+      render(Fret, {
+        note: 'C',
+        fretNumber: 0,
+        stringNumber: 0
+      });
     });
   
     afterEach(() => {
@@ -23,32 +27,36 @@ describe('<Fret />', () => {
     });
   
     it('Should render', () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toBeInTheDocument();
     });
   
     it('Should set aria-current to false', () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toHaveAttribute('aria-current', 'false');
     });
   
     it('Should set aria-current to location when clicked', async () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toHaveAttribute('aria-current', 'false');
       await userEvent.click(fret);
       expect(fret).toHaveAttribute('aria-current', 'location');
     });
 
     it('Should set aria-selected to false', () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toHaveAttribute('aria-selected', 'false');
     });
   });
 
   describe('When the note is selected', () => {
     beforeEach(async () => {
-      render(Fret, { note: 'C' });
-      const fret = screen.getByRole('button', { name: /C/ });
+      render(Fret, {
+        note: 'C',
+        fretNumber: 0,
+        stringNumber: 0
+      });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       await userEvent.click(fret);
     });
   
@@ -57,20 +65,24 @@ describe('<Fret />', () => {
     });
 
     it('Should set aria-current to location', () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toHaveAttribute('aria-current', 'location');
     });
   
-    it('Should set aria-current to false when clicked', async () => {
-      const fret = screen.getByRole('button', { name: /C/ });
-      await userEvent.click(fret);
+    it('Should set aria-current to false when clicked away', async () => {
+      const fret = screen.getByRole('gridcell', { name: /C/ });
+      await userEvent.click(document.body);
       expect(fret).toHaveAttribute('aria-current', 'false');
     });
   });
 
   describe('When the note is highlighted', () => {
     beforeEach(() => {
-      render(Fret, { note: 'C' });
+      render(Fret, {
+        note: 'C',
+        fretNumber: 0,
+        stringNumber: 0
+      });
       highlightedNotes.set([
         {
           color: '#ff0000',
@@ -91,14 +103,14 @@ describe('<Fret />', () => {
     });
   
     it('Should display a tooltip when hovered', async () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       await userEvent.hover(fret);
       const tooltip = screen.getByRole('tooltip', { name: 'Root' });
       expect(tooltip).toBeInTheDocument();
     });
 
     it('Should set aria-selected to true', () => {
-      const fret = screen.getByRole('button', { name: /C/ });
+      const fret = screen.getByRole('gridcell', { name: /C/ });
       expect(fret).toHaveAttribute('aria-selected', 'true');
     });
   });

--- a/tests/components/Guitar/subcomponents/String.test.ts
+++ b/tests/components/Guitar/subcomponents/String.test.ts
@@ -9,7 +9,8 @@ describe('<String />', () => {
   beforeEach(() => {
     render(String, {
       tuning,
-      numberOfFrets
+      numberOfFrets,
+      stringNumber: 0
     });
   });
 
@@ -19,12 +20,12 @@ describe('<String />', () => {
   });
 
   it('Should start with the correct tuning', () => {
-    const frets = screen.getAllByRole('button');
+    const frets = screen.getAllByRole('gridcell');
     expect(frets[0]).toHaveTextContent(tuning);
   });
 
   it('Should render the correct number of frets, including open string', () => {
-    const frets = screen.getAllByRole('button');
+    const frets = screen.getAllByRole('gridcell');
     expect(frets.length).toBe(numberOfFrets + 1);
   });
 });

--- a/tests/components/Guitar/subcomponents/String.test.ts
+++ b/tests/components/Guitar/subcomponents/String.test.ts
@@ -15,7 +15,7 @@ describe('<String />', () => {
   });
 
   it('Should render', () => {
-    const string = screen.getByTestId('guitar-string');
+    const string = screen.getByRole('row');
     expect(string).toBeInTheDocument();
   });
 


### PR DESCRIPTION
# #88 Convert guitar to navigable grid

Converted the guitar fretboard into a grid that's navigable via keyboard

## Changes

- **Converted guitar to html table grid**
- **Set basic keyboard navigation for guitar fretboard**
- **Set note to be selected on focus instead of click**
- **Unselected note when leaving fret focus**
- **Applied styles to distinguish between focus and selected indicators**
- **Set current highlighted notes to be visually different to selected scale notes**
