### PR TITLE
#154 Fix missing piano key outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "globals": "15.12.0",
     "jsdom": "25.0.1",
     "sass": "1.80.6",
-    "svelte": "5.1.10",
+    "svelte": "5.1.11",
     "svelte-check": "4.0.5",
     "tslib": "2.8.1",
     "typescript": "5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 2.10.1(eslint@9.14.0)(typescript@5.6.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.0
-        version: 4.0.0(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
+        version: 4.0.0(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
       '@testing-library/jest-dom':
         specifier: 6.6.3
         version: 6.6.3
       '@testing-library/svelte':
         specifier: 5.2.4
-        version: 5.2.4(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))(vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.6))
+        version: 5.2.4(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))(vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.6))
       '@testing-library/user-event':
         specifier: 14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
@@ -43,7 +43,7 @@ importers:
         version: 9.14.0
       eslint-plugin-svelte:
         specifier: 2.46.0
-        version: 2.46.0(eslint@9.14.0)(svelte@5.1.10)
+        version: 2.46.0(eslint@9.14.0)(svelte@5.1.11)
       globals:
         specifier: 15.12.0
         version: 15.12.0
@@ -54,11 +54,11 @@ importers:
         specifier: 1.80.6
         version: 1.80.6
       svelte:
-        specifier: 5.1.10
-        version: 5.1.10
+        specifier: 5.1.11
+        version: 5.1.11
       svelte-check:
         specifier: 4.0.5
-        version: 4.0.5(picomatch@4.0.2)(svelte@5.1.10)(typescript@5.6.3)
+        version: 4.0.5(picomatch@4.0.2)(svelte@5.1.11)(typescript@5.6.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -1494,8 +1494,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.1.10:
-    resolution: {integrity: sha512-lDR04z/5taV2qhqYt7UXQ3sVuv/FVfbHz4UBQpYP9Xlcv2OV0rw74hkZ7kbdZr3UKLgGdIGxG2UBxtRmgzB2Cg==}
+  svelte@5.1.11:
+    resolution: {integrity: sha512-XpPcUBKCg2c+L0nDTkv0ekc8LOHMzN328MNOeAHt4sRcX5AROU9tkqwL35VvE6srt8RpmnzsXBGDwyRB5TSbuw==}
     engines: {node: '>=18'}
 
   symbol-tree@3.2.4:
@@ -2035,23 +2035,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6)))(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6)))(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
       debug: 4.3.7
-      svelte: 5.1.10
+      svelte: 5.1.11
       vite: 5.4.10(@types/node@22.9.0)(sass@1.80.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6)))(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6)))(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
-      svelte: 5.1.10
+      svelte: 5.1.11
       vite: 5.4.10(@types/node@22.9.0)(sass@1.80.6)
       vitefu: 1.0.3(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))
     transitivePeerDependencies:
@@ -2078,10 +2078,10 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.4(svelte@5.1.10)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))(vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.6))':
+  '@testing-library/svelte@5.2.4(svelte@5.1.11)(vite@5.4.10(@types/node@22.9.0)(sass@1.80.6))(vitest@2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.6))':
     dependencies:
       '@testing-library/dom': 10.4.0
-      svelte: 5.1.10
+      svelte: 5.1.11
     optionalDependencies:
       vite: 5.4.10(@types/node@22.9.0)(sass@1.80.6)
       vitest: 2.1.4(@types/node@22.9.0)(jsdom@25.0.1)(sass@1.80.6)
@@ -2475,7 +2475,7 @@ snapshots:
       eslint: 9.14.0
       semver: 7.6.3
 
-  eslint-plugin-svelte@2.46.0(eslint@9.14.0)(svelte@5.1.10):
+  eslint-plugin-svelte@2.46.0(eslint@9.14.0)(svelte@5.1.11):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.14.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -2488,9 +2488,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.43.0(svelte@5.1.10)
+      svelte-eslint-parser: 0.43.0(svelte@5.1.11)
     optionalDependencies:
-      svelte: 5.1.10
+      svelte: 5.1.11
     transitivePeerDependencies:
       - ts-node
 
@@ -3064,19 +3064,19 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte-check@4.0.5(picomatch@4.0.2)(svelte@5.1.10)(typescript@5.6.3):
+  svelte-check@4.0.5(picomatch@4.0.2)(svelte@5.1.11)(typescript@5.6.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.1
       fdir: 6.4.2(picomatch@4.0.2)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.1.10
+      svelte: 5.1.11
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.43.0(svelte@5.1.10):
+  svelte-eslint-parser@0.43.0(svelte@5.1.11):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -3084,9 +3084,9 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.1.10
+      svelte: 5.1.11
 
-  svelte@5.1.10:
+  svelte@5.1.11:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/renovate.json
+++ b/renovate.json
@@ -23,8 +23,7 @@
       "matchUpdateTypes": [
         "minor",
         "patch"
-      ],
-      "automerge": true
+      ]
     },
     {
       "groupName": "all pin dependencies",


### PR DESCRIPTION
# #154 Fix missing piano key outline

Fixed missing piano outlines between keys

## Description

Fixes a bug in Svelte by upgrading to 5.1.11

Also removed auto-merge for minor & patch updates to prevent making bugs live whilst there's no staging area

## Changes

- **Removed automerge from non major dependency updates**
- **Updated svelte to 5.1.11**

